### PR TITLE
Warn on clippy and usage of rust 2018 idoms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@
 //! [r3bl-ts-utils](https://github.com/r3bl-org/r3bl-ts-utils/). We have since switched to Rust
 //! 🦀🎉.
 
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
+
 // Attach the following files to the library module.
 pub mod redux;
 pub mod tree_memory_arena;

--- a/src/tree_memory_arena/arena.rs
+++ b/src/tree_memory_arena/arena.rs
@@ -131,7 +131,7 @@ where
 {
   /// If no matching nodes can be found returns `None`.
   pub fn filter_all_nodes_by(&self, filter_fn: &FilterFn<T>) -> ResultUidList {
-    let map: ReadGuarded<ArenaMap<T>> = self.map.read().unwrap();
+    let map: ReadGuarded<'_, ArenaMap<T>> = self.map.read().unwrap();
     let filtered_map = map
       .iter()
       .filter(|(id, node_ref)| filter_fn(**id, node_ref.read().unwrap().payload.clone()))
@@ -149,7 +149,7 @@ where
       return None;
     }
     let node_to_lookup = self.get_node_arc(node_id)?;
-    let node_to_lookup: ReadGuarded<Node<T>> = node_to_lookup.read().unwrap(); // Safe to call unwrap.
+    let node_to_lookup: ReadGuarded<'_, Node<T>> = node_to_lookup.read().unwrap(); // Safe to call unwrap.
     let children_uids = &node_to_lookup.children;
     Some(children_uids.clone())
   }
@@ -160,7 +160,7 @@ where
       return None;
     }
     let node_to_lookup = self.get_node_arc(node_id)?;
-    let node_to_lookup: ReadGuarded<Node<T>> = node_to_lookup.read().unwrap(); // Safe to call unwrap.
+    let node_to_lookup: ReadGuarded<'_, Node<T>> = node_to_lookup.read().unwrap(); // Safe to call unwrap.
     node_to_lookup.parent
   }
 
@@ -202,7 +202,7 @@ where
     }
 
     // Actually delete the nodes in the deletion list.
-    let mut map: WriteGuarded<ArenaMap<T>> = self.map.write().unwrap(); // Safe to unwrap.
+    let mut map: WriteGuarded<'_, ArenaMap<T>> = self.map.write().unwrap(); // Safe to unwrap.
     deletion_list.iter().for_each(|id| {
       map.remove(id);
     });

--- a/src/tree_memory_arena/mt_arena.rs
+++ b/src/tree_memory_arena/mt_arena.rs
@@ -126,7 +126,7 @@ where
     let walker_fn_arc = walker_fn.clone();
 
     spawn(move || {
-      let read_guard: ReadGuarded<Arena<T>> = arena_arc.read().unwrap();
+      let read_guard: ReadGuarded<'_, Arena<T>> = arena_arc.read().unwrap();
       let return_value = read_guard.tree_walk_dfs(node_id);
 
       // While walking the tree, in a separate thread, call the `walker_fn` for each
@@ -135,7 +135,7 @@ where
         result_list.into_iter().for_each(|uid| {
           let node_arc_opt = read_guard.get_node_arc(uid);
           if let Some(node_arc) = node_arc_opt {
-            let node_ref: ReadGuarded<Node<T>> = node_arc.read().unwrap();
+            let node_ref: ReadGuarded<'_, Node<T>> = node_arc.read().unwrap();
             walker_fn_arc(uid, node_ref.payload.clone());
           }
         });

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -211,9 +211,6 @@
 //! 1. [Code example of an address book using Redux](https://github.com/r3bl-org/address-book-with-redux-tui).
 //! 2. [Code example of TUI apps using Redux](https://github.com/r3bl-org/r3bl-cmdr).
 
-/// Use bitflags! macro.
-extern crate bitflags;
-
 // Attach sources.
 pub mod crossterm_helpers;
 pub mod layout;

--- a/src/utils/safe_unwrap.rs
+++ b/src/utils/safe_unwrap.rs
@@ -50,7 +50,7 @@ where
   F: FnMut(&T) -> R,
 {
   let arc_clone = arc_lock_wrapped_value.clone();
-  let read_guarded: ReadGuarded<T> = unwrap!(r_lock from arc_clone);
+  let read_guarded: ReadGuarded<'_, T> = unwrap!(r_lock from arc_clone);
   receiver_fn(&read_guarded)
 }
 
@@ -61,7 +61,7 @@ where
   F: FnMut(&mut T) -> R,
 {
   let arc_clone = arc_lock_wrapped_value.clone();
-  let mut write_guarded: WriteGuarded<T> = unwrap!(w_lock from arc_clone);
+  let mut write_guarded: WriteGuarded<'_, T> = unwrap!(w_lock from arc_clone);
   receiver_fn(&mut write_guarded)
 }
 


### PR DESCRIPTION
It is good practice to use enforce Clippy's suggestions and the usage of 2018 idioms as warnings. Why not errors? During development, it is nice to be able to iterate without caring about Clippy. 

Also removed is the usage of deprecated 2018 hidden lifetimes. It also seems like the external crate export was unused.