### PR TITLE
CreateAFunctionThatAllowsMultipleSelectionsFromAListOfStrings

### DIFF
--- a/tuify/examples/main_interactive.rs
+++ b/tuify/examples/main_interactive.rs
@@ -42,7 +42,8 @@ fn main() -> Result<()> {
         .collect(),
         max_height_row_count,
         max_width_col_count,
-        SelectionMode::Single,
+        // SelectionMode::Single,
+        SelectionMode::Multiple,
     );
 
     match &user_input {

--- a/tuify/examples/main_interactive.rs
+++ b/tuify/examples/main_interactive.rs
@@ -17,6 +17,7 @@
 
 use std::io::Result;
 
+use crossterm::style::Stylize;
 use r3bl_rs_utils_core::*;
 use r3bl_tuify::*;
 
@@ -32,6 +33,13 @@ fn main() -> Result<()> {
         get_size().map(|it| it.col_count).unwrap_or(ch!(80)).into();
     let max_height_row_count: usize = 5;
 
+    // Single select.
+    println!(
+        "{}",
+        "Single select (move up and down, press enter or esc)"
+            .yellow()
+            .on_dark_blue()
+    );
     let user_input = select_from_list(
         [
             "item 1", "item 2", "item 3", "item 4", "item 5", "item 6", "item 7",
@@ -42,7 +50,33 @@ fn main() -> Result<()> {
         .collect(),
         max_height_row_count,
         max_width_col_count,
-        // SelectionMode::Single,
+        SelectionMode::Single,
+    );
+
+    match &user_input {
+        Some(it) => {
+            println!("User selected: {:?}", it);
+        }
+        None => println!("User did not select anything"),
+    }
+
+    // Multiple select.
+    println!(
+        "{}",
+        "Multiple select (move up and down, press space, then enter or esc)"
+            .yellow()
+            .on_dark_blue()
+    );
+    let user_input = select_from_list(
+        [
+            "item 1", "item 2", "item 3", "item 4", "item 5", "item 6", "item 7",
+            "item 8", "item 9", "item 10",
+        ]
+        .iter()
+        .map(|it| it.to_string())
+        .collect(),
+        max_height_row_count,
+        max_width_col_count,
         SelectionMode::Multiple,
     );
 

--- a/tuify/src/components/mod.rs
+++ b/tuify/src/components/mod.rs
@@ -15,6 +15,6 @@
  *   limitations under the License.
  */
 
-pub mod single_select_component;
+pub mod select_component;
 
-pub use single_select_component::*;
+pub use select_component::*;

--- a/tuify/src/components/select_component.rs
+++ b/tuify/src/components/select_component.rs
@@ -23,11 +23,11 @@ use r3bl_rs_utils_core::*;
 
 use crate::*;
 
-pub struct SingleSelectComponent<W: Write> {
+pub struct SelectComponent<W: Write> {
     pub write: W,
 }
 
-impl<W: Write> FunctionComponent<W, State> for SingleSelectComponent<W> {
+impl<W: Write> FunctionComponent<W, State> for SelectComponent<W> {
     fn get_write(&mut self) -> &mut W { &mut self.write }
 
     /// If there are more items than the max display height, then we only use max display
@@ -92,6 +92,13 @@ impl<W: Write> FunctionComponent<W, State> for SingleSelectComponent<W> {
             };
 
             let data_item = &state.items[data_row_index];
+            // Invert colors for selected items.
+            let (fg_color, bg_color) = if state.selected_items.contains(data_item) {
+                (bg_color, fg_color)
+            } else {
+                (fg_color, bg_color)
+            };
+
             let data_item = format!("{row_prefix}{data_item}");
             let data_item = clip_string_to_width_with_ellipsis(data_item, viewport_width);
 

--- a/tuify/src/event_loop.rs
+++ b/tuify/src/event_loop.rs
@@ -27,6 +27,7 @@ pub enum EventLoopResult {
     ExitWithResult(Vec<String>),
     ExitWithoutResult,
     ExitWithError,
+    Select,
 }
 
 // TODO: add performance using output buffer
@@ -51,7 +52,7 @@ pub fn enter_event_loop<W: Write, S>(
                 // Continue the loop.
                 function_component.render(state)?;
             }
-            EventLoopResult::Continue => {
+            EventLoopResult::Continue | EventLoopResult::Select => {
                 // Noop. Simply continue the loop.
             }
             EventLoopResult::ExitWithResult(it) => {

--- a/tuify/src/keypress.rs
+++ b/tuify/src/keypress.rs
@@ -33,6 +33,7 @@ pub enum KeyPress {
     #[default]
     Noop,
     Error,
+    Space,
 }
 
 pub fn read_key_press() -> KeyPress {
@@ -58,6 +59,7 @@ fn read_key_press_unix() -> KeyPress {
                         crossterm::event::KeyCode::Down => KeyPress::Down,
                         crossterm::event::KeyCode::Enter => KeyPress::Enter,
                         crossterm::event::KeyCode::Esc => KeyPress::Esc,
+                        crossterm::event::KeyCode::Char(' ') => KeyPress::Space,
                         _ => KeyPress::Noop,
                     }
                 }
@@ -112,6 +114,14 @@ fn read_key_press_windows() -> KeyPress {
                     kind: KeyEventKind::Press, // This is for Windows.
                     state: KeyEventState::NONE,
                 }) => KeyPress::Esc,
+
+                // Space.
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char(' '),
+                    modifiers: KeyModifiers::NONE,
+                    kind: KeyEventKind::Press, // This is for Windows.
+                    state: KeyEventState::NONE,
+                }) => KeyPress::Space,
 
                 // Catchall.
                 _ => KeyPress::Noop,

--- a/tuify/src/state.rs
+++ b/tuify/src/state.rs
@@ -28,6 +28,7 @@ pub struct State {
     pub raw_caret_row_index: ChUnit,
     pub scroll_offset_row_index: ChUnit,
     pub items: Vec<String>,
+    pub selected_items: Vec<String>,
 }
 
 impl State {


### PR DESCRIPTION
CreateAFunctionThatAllowsMultipleSelectionsFromAListOfStrings
===

## Overview

- Resolves issue #123 

## Details

### SelectComponent

- Renamed from `SingleSelectComponent`.
- Added `if/else` statement to invert `fg_color` and `bg_color` if item is present in `State.selected_items`.

### KeyPress

- Added `Space`.
- Use `KeyCode::Char(' ')` to capture space presses.

### PublicApi

- Added branch to match expression to capture `KeyPress::Enter` with guard statement for `SelectionMode::Multiple`:
    -  Will return `EventLoopResult::ExitWithoutResult` or `EventLoopResult::ExitWithResult` depending on if `State.selected_items` is empty.
- Added branch to match expression to capture `KeyPress::Space` with guard statement for `SelectionMode::Multiple`:
    - If item is already in `State.selected_items`, remove it, otherwise add it.

### State

- Added `selected_items` field to capture items when `SelectionMode::Multiple` is used.

## Testing

- Updated `main_interactive.rs` to use `SelectionMode::Multiple`.
- Run `just run`.
- Use `space` to select and de-select items:
    - Observe that selected items have their `bg_color` and `fg_color` inverted.
- Press `enter`:
    - Observe that only the selected items are displayed.  
