### PR TITLE
AddStylingSupportSoThatSelectedAndUnselectedStylesCanBePassedIn

### DIFF
--- a/tuify/examples/main_interactive.rs
+++ b/tuify/examples/main_interactive.rs
@@ -33,6 +33,8 @@ fn main() -> Result<()> {
         get_size().map(|it| it.col_count).unwrap_or(ch!(80)).into();
     let max_height_row_count: usize = 5;
 
+    let style = StyleSheet::default();
+
     // Single select.
     {
         // 2 items & viewport height = 5.
@@ -51,6 +53,7 @@ fn main() -> Result<()> {
             max_height_row_count,
             max_width_col_count,
             SelectionMode::Single,
+            style,
         );
         match &user_input {
             Some(it) => {
@@ -89,6 +92,7 @@ fn main() -> Result<()> {
             max_height_row_count,
             max_width_col_count,
             SelectionMode::Single,
+            style,
         );
         match &user_input {
             Some(it) => {
@@ -119,6 +123,7 @@ fn main() -> Result<()> {
             max_height_row_count,
             max_width_col_count,
             SelectionMode::Multiple,
+            style,
         );
         match &user_input {
             Some(it) => {
@@ -149,6 +154,7 @@ fn main() -> Result<()> {
             max_height_row_count,
             max_width_col_count,
             SelectionMode::Multiple,
+            style,
         );
         match &user_input {
             Some(it) => {

--- a/tuify/src/components/apply_style_macro.rs
+++ b/tuify/src/components/apply_style_macro.rs
@@ -1,0 +1,72 @@
+/*
+ *   Copyright (c) 2023 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+use crossterm::style::*;
+
+#[macro_export]
+macro_rules! apply_style {
+    ($style: expr => bg_color) => {
+        SetBackgroundColor(Color::AnsiValue($style.bg_color.as_ansi256().index))
+    };
+    ($style: expr => bg_color) => {
+        SetBackgroundColor(Color::AnsiValue($style.bg_color.as_ansi256().index))
+    };
+    ($style: expr => fg_color) => {
+        SetForegroundColor(Color::AnsiValue($style.fg_color.as_ansi256().index))
+    };
+    ($style: expr => bold) => {
+        set_attribute($style.bold, Attribute::Italic, Attribute::NoItalic)
+    };
+    ($style: expr => italic) => {
+        set_attribute($style.italic, Attribute::Italic, Attribute::NoItalic)
+    };
+    ($style: expr => dim) => {
+        set_attribute($style.dim, Attribute::Dim, Attribute::NormalIntensity)
+    };
+    ($style: expr => underline) => {
+        set_attribute(
+            $style.underline,
+            Attribute::Underlined,
+            Attribute::NoUnderline,
+        )
+    };
+    ($style: expr => reverse) => {
+        set_attribute($style.reverse, Attribute::Reverse, Attribute::NoReverse)
+    };
+    ($style: expr => hidden) => {
+        set_attribute($style.hidden, Attribute::Hidden, Attribute::NoHidden)
+    };
+    ($style: expr => strikethrough) => {
+        set_attribute(
+            $style.strikethrough,
+            Attribute::CrossedOut,
+            Attribute::NotCrossedOut,
+        )
+    };
+}
+
+pub fn set_attribute(
+    enable: bool,
+    attribute: Attribute,
+    no_attribute: Attribute,
+) -> SetAttribute {
+    if enable {
+        SetAttribute(attribute)
+    } else {
+        SetAttribute(no_attribute)
+    }
+}

--- a/tuify/src/components/apply_style_macro.rs
+++ b/tuify/src/components/apply_style_macro.rs
@@ -16,17 +16,37 @@
  */
 
 use crossterm::style::*;
+use r3bl_ansi_color::{detect_color_support,
+                      Color as RColor,
+                      ColorSupport,
+                      TransformColor};
+
+pub fn get_crossterm_color_based_on_terminal_capabilities(color: RColor) -> Color {
+    let detect_color_support = detect_color_support();
+    match detect_color_support {
+        ColorSupport::Truecolor => {
+            let rgb_color = color.as_rgb();
+            Color::Rgb {
+                r: rgb_color.red,
+                g: rgb_color.green,
+                b: rgb_color.blue,
+            }
+        }
+        _ => Color::AnsiValue(color.as_ansi256().index),
+    }
+}
 
 #[macro_export]
 macro_rules! apply_style {
     ($style: expr => bg_color) => {
-        SetBackgroundColor(Color::AnsiValue($style.bg_color.as_ansi256().index))
-    };
-    ($style: expr => bg_color) => {
-        SetBackgroundColor(Color::AnsiValue($style.bg_color.as_ansi256().index))
+        SetBackgroundColor(get_crossterm_color_based_on_terminal_capabilities(
+            $style.bg_color,
+        ))
     };
     ($style: expr => fg_color) => {
-        SetForegroundColor(Color::AnsiValue($style.fg_color.as_ansi256().index))
+        SetForegroundColor(get_crossterm_color_based_on_terminal_capabilities(
+            $style.fg_color,
+        ))
     };
     ($style: expr => bold) => {
         set_attribute($style.bold, Attribute::Italic, Attribute::NoItalic)

--- a/tuify/src/components/mod.rs
+++ b/tuify/src/components/mod.rs
@@ -18,3 +18,12 @@
 pub mod select_component;
 
 pub use select_component::*;
+
+pub mod style;
+
+pub use style::*;
+
+#[macro_use]
+pub mod apply_style_macro;
+
+pub use apply_style_macro::*;

--- a/tuify/src/components/select_component.rs
+++ b/tuify/src/components/select_component.rs
@@ -18,7 +18,6 @@
 use std::io::{Result, *};
 
 use crossterm::{cursor::*, queue, style::*, terminal::*};
-use r3bl_ansi_color::TransformColor;
 use r3bl_rs_utils_core::*;
 
 use crate::*;
@@ -46,7 +45,6 @@ impl<W: Write> FunctionComponent<W, State> for SelectComponent<W> {
     /// lines.
     fn render(&mut self, state: &mut State) -> Result<()> {
         // Setup the required data.
-        // Clone required here since `get_write` borrows self mutably.
         let normal_style = self.style.normal_style;
         let header_style = self.style.header_style;
         let selected_style = self.style.selected_style;

--- a/tuify/src/components/style.rs
+++ b/tuify/src/components/style.rs
@@ -1,0 +1,76 @@
+/*
+ *   Copyright (c) 2023 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+use r3bl_ansi_color::Color;
+
+#[derive(Copy, Clone, Debug)]
+pub struct StyleSheet {
+    pub normal_style: Style,
+    pub selected_style: Style,
+    pub header_style: Style,
+}
+
+impl Default for StyleSheet {
+    fn default() -> Self {
+        let normal_style = Style::default();
+        let selected_style = Style {
+            fg_color: normal_style.bg_color,
+            bg_color: normal_style.fg_color,
+            ..Style::default()
+        };
+        let header_style = Style {
+            fg_color: Color::Rgb(250, 200, 200),
+            bg_color: Color::Rgb(100, 160, 150),
+            bold: true,
+            ..Style::default()
+        };
+        StyleSheet {
+            normal_style,
+            selected_style,
+            header_style,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Style {
+    pub bold: bool,
+    pub italic: bool,
+    pub dim: bool,
+    pub underline: bool,
+    pub reverse: bool,
+    pub hidden: bool,
+    pub strikethrough: bool,
+    pub fg_color: Color,
+    pub bg_color: Color,
+}
+
+impl Default for Style {
+    fn default() -> Self {
+        Style {
+            bold: false,
+            italic: false,
+            dim: false,
+            underline: false,
+            reverse: false,
+            hidden: false,
+            strikethrough: false,
+            fg_color: Color::Rgb(200, 200, 1),
+            bg_color: Color::Rgb(100, 60, 150),
+        }
+    }
+}

--- a/tuify/src/main.rs
+++ b/tuify/src/main.rs
@@ -216,6 +216,7 @@ fn show_tui(
             max_height_row_count,
             max_width_col_count,
             SelectionMode::Single,
+            StyleSheet::default(),
         );
 
         let it = if let Some(user_selection) = user_selection {
@@ -278,6 +279,7 @@ fn show_tui(
             max_height_row_count,
             max_width_col_count,
             selection_mode,
+            StyleSheet::default(),
         );
         convert_user_input_into_vec_of_strings(it)
     };

--- a/tuify/src/public_api.rs
+++ b/tuify/src/public_api.rs
@@ -34,6 +34,7 @@ pub fn select_from_list(
     max_height_row_count: usize,
     max_width_col_count: usize,
     selection_mode: SelectionMode,
+    style: StyleSheet,
 ) -> Option<Vec<String>> {
     // There are fewer items than viewport height. So make viewport shorter.
     let max_height_row_count = if items.len() <= max_height_row_count {
@@ -52,7 +53,10 @@ pub fn select_from_list(
         header,
     };
 
-    let mut function_component = SelectComponent { write: stdout() };
+    let mut function_component = SelectComponent {
+        write: stdout(),
+        style,
+    };
 
     let user_input = enter_event_loop(
         &mut state,


### PR DESCRIPTION
AddStylingSupportSoThatSelectedAndUnselectedStylesCanBePassedIn
===

# Overview

- resolves #116 
- Add `Style` struct and updates `SelectComponent` to make use of it.

# Details

## Style

Accepts fields for:
    - Foreground color: Color
    - Background color: Color
    - Bold: bool
    - Italic: bool
    - Dim: bool
    - Underline: bool
    - Reverse: bool
    - Strikethrough: bool

## StyleSheet

- Has following fields:
    - normal_style:
        - Default just takes what was already in `SelectComponent` and moves it here. 
    - selected_style
        - Default is the same as normal style with swapped foreground/background colors. 
    - header_style
        - Default just takes what was already in `SelectComponent` and moves it here. 

## apply_style_macro

- Declarative macro.
- Handles generating the inputs for the `queue!` macro used in `SelectComponent`.
- Has pattern for each of the above styles.
- Generates `SetForegroundColor`, `SetBackgroundColor`, and `SetAttributes` as needed.

## SelectComponent

- Updated to make use of `StyleSheet`, `Style`s, and the `apply_style!` macro.

## PublicApi

- Pass default `StyleSheet` to `SelectComponent`.

# Testing

- Make `style` `mut` in `main_interactive.rs`.
- Make changes to the various styles and observe that they are reflected in the terminal.

> [!NOTE]
> Normally I use Alacritty as my terminal but changes to the style were not reflected in it.
> However, they did work in Konsole.