### PR TITLE
Audit crates

### DIFF
--- a/ansi_color/README.md
+++ b/ansi_color/README.md
@@ -142,5 +142,5 @@ Here are some links:
 1. <https://docs.rs/anstyle-query/latest/anstyle_query/fn.term_supports_ansi_color.html>
 1. <https://crates.io/crates/anstyle-query>
 1. <https://docs.rs/supports-color/2.0.0/supports_color/>
-1. <https://crates.io/crates/r3bl_ansi_color>
+1. <https://crates.io/crates/r3bl_ansi_color> (the source in `ansi_color` folder is this crate)
 1. <https://crates.io/crates/colored>

--- a/ansi_color/README.md
+++ b/ansi_color/README.md
@@ -142,5 +142,5 @@ Here are some links:
 1. <https://docs.rs/anstyle-query/latest/anstyle_query/fn.term_supports_ansi_color.html>
 1. <https://crates.io/crates/anstyle-query>
 1. <https://docs.rs/supports-color/2.0.0/supports_color/>
-1. <https://crates.io/crates/ansi_colours>
+1. <https://crates.io/crates/r3bl_ansi_color>
 1. <https://crates.io/crates/colored>

--- a/ansi_color/src/lib.rs
+++ b/ansi_color/src/lib.rs
@@ -163,7 +163,7 @@
 //! 1. <https://docs.rs/anstyle-query/latest/anstyle_query/fn.term_supports_ansi_color.html>
 //! 1. <https://crates.io/crates/anstyle-query>
 //! 1. <https://docs.rs/supports-color/2.0.0/supports_color/>
-//! 1. <https://crates.io/crates/r3bl_ansi_color>
+//! 1. <https://crates.io/crates/r3bl_ansi_color> (the source in `ansi_color` folder is this crate)
 //! 1. <https://crates.io/crates/colored>
 
 // https://github.com/rust-lang/rust-clippy

--- a/ansi_color/src/lib.rs
+++ b/ansi_color/src/lib.rs
@@ -163,7 +163,7 @@
 //! 1. <https://docs.rs/anstyle-query/latest/anstyle_query/fn.term_supports_ansi_color.html>
 //! 1. <https://crates.io/crates/anstyle-query>
 //! 1. <https://docs.rs/supports-color/2.0.0/supports_color/>
-//! 1. <https://crates.io/crates/ansi_colours>
+//! 1. <https://crates.io/crates/r3bl_ansi_color>
 //! 1. <https://crates.io/crates/colored>
 
 // https://github.com/rust-lang/rust-clippy

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,8 +63,8 @@ syntect = "5.0.0"
 # nom parser combinator.
 nom = "7.1.3"
 
-# ansi_colours convert between ansi and rgb.
-ansi_colours = "1.2.1"
+# convert between ansi and rgb.
+r3bl_ansi_color = "0.6.7"
 
 # for assert_eq! macro
 pretty_assertions = "1.3.0"

--- a/core/src/tui_core/styles/tui_color.rs
+++ b/core/src/tui_core/styles/tui_color.rs
@@ -209,22 +209,26 @@ impl Default for RgbValue {
 }
 
 mod convert_rgb_ansi_values {
+    use r3bl_ansi_color::TransformColor;
+
     use super::*;
 
     impl From<RgbValue> for AnsiValue {
         fn from(rgb_value: RgbValue) -> Self {
-            let red = rgb_value.red;
-            let green = rgb_value.green;
-            let blue = rgb_value.blue;
-            let ansi_color = ansi_colours::ansi256_from_rgb((red, green, blue));
+            let rgb_color = r3bl_ansi_color::RgbColor {
+                red: rgb_value.red,
+                green: rgb_value.green,
+                blue: rgb_value.blue,
+            };
+            let ansi_color = r3bl_ansi_color::convert_rgb_into_ansi256(rgb_color).index;
             Self::new(ansi_color)
         }
     }
 
     impl From<AnsiValue> for RgbValue {
         fn from(ansi_value: AnsiValue) -> Self {
-            let color = ansi_value.color;
-            let (red, green, blue) = ansi_colours::rgb_from_ansi256(color);
+            let rgb_color = r3bl_ansi_color::Ansi256Color{index : ansi_value.color}.as_rgb();
+            let (red, green, blue) = (rgb_color.red, rgb_color.green, rgb_color.blue);
             Self::from_u8(red, green, blue)
         }
     }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,10 @@
+[licenses]
+unlicensed = "deny"
+allow = ["MIT", "Apache-2.0"]
+copyleft = "deny"
+
+exceptions = [
+    { name = "unicode-ident", allow = ["Unicode-DFS-2016"] }, 
+    { name = "encoding_rs", allow = ["BSD-3-Clause"] },
+    { name = "is_ci" , allow = ["ISC"] }
+]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -82,7 +82,7 @@ pretty_assertions = "1.3.0"
 concolor-query = "0.3.3"
 
 # ANSI to RGB colors.
-ansi_colours = "1.2.1"
+r3bl_ansi_color = "0.6.7"
 
 # Terminal
 ansi_term = "0.12.1"


### PR DESCRIPTION
- [X] ansi_colours crate has to be dropped & replaced with [this](https://crates.io/crates/r3bl_ansi_color).
- [ ] This license audit step has to be added to the https://github.com/r3bl-org/r3bl_rs_utils/issues/120 work that we have planned as well.
- [X] Add an exception for three crates (unicode-indent, encoding_rs,is_ci) using (Unicode-DFS-2016, BSD-3-Clause,ISC) to deny.toml

Closes #112 