### PR TITLE
[core] remove `reqwest` and license exception `encoding-rs`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,9 +26,6 @@ tokio = { version = "1.27.0", features = ["full"] }
 async-trait = "0.1.68"
 ansi_term = "0.12.1"
 
-# HTTP Client.
-reqwest = { version = "0.11.16", features = ["json"] }
-
 # https://github.com/serde-rs/serde.
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/core/README.md
+++ b/core/README.md
@@ -299,48 +299,6 @@ let my_string = "Hello World!";
 trace_log_no_err!(my_string);
 ```
 
-#### make_api_call_for!
-<a id="markdown-make_api_call_for!" name="make_api_call_for!"></a>
-
-
-This macro makes it easy to create simple HTTP GET requests using the `reqwest` crate. It generates
-an `async` function called `make_request()` that returns a `CommonResult<T>` where `T` is the type
-of the response body. Here's an example.
-
-```rust
-use std::{error::Error, fmt::Display};
-use r3bl_rs_utils::make_api_call_for;
-use serde::{Deserialize, Serialize};
-
-const ENDPOINT: &str = "https://api.namefake.com/english-united-states/female/";
-
-make_api_call_for! {
-  FakeContactData at ENDPOINT
-}
-#[derive(Serialize, Deserialize, Debug, Default)]
-
-pub struct FakeContactData {
-  pub name: String,
-  pub phone_h: String,
-  pub email_u: String,
-  pub email_d: String,
-  pub address: String,
-}
-
-let fake_data = fake_contact_data_api()
-            .await
-            .unwrap_or_else(|_| FakeContactData {
-              name: "Foo Bar".to_string(),
-              phone_h: "123-456-7890".to_string(),
-              email_u: "foo".to_string(),
-              email_d: "bar.com".to_string(),
-              ..FakeContactData::default()
-            });
-```
-
-You can find lots of
-[examples here](https://github.com/r3bl-org/address-book-with-redux-tui/blob/main/src/tui/middlewares).
-
 #### fire_and_forget!
 <a id="markdown-fire_and_forget!" name="fire_and_forget!"></a>
 

--- a/core/src/decl_macros.rs
+++ b/core/src/decl_macros.rs
@@ -224,32 +224,6 @@ macro_rules! debug {
   }};
 }
 
-/// Declarative macro to generate the API call functions. This adds the
-/// following:
-/// - `make_request()` async function to call the API.
-/// - `to_string()` function to stringify the struct to JSON.
-/// - impl `Display` trait to for the struct using `to_string()` above.
-#[macro_export]
-macro_rules! make_api_call_for {
-    ($IDENT:ident at $ENDPOINT:ident) => {
-        pub async fn make_request() -> Result<$IDENT, Box<dyn Error>> {
-            let res = reqwest::get($ENDPOINT).await?;
-            let res_text = res.text().await?;
-            let res_json: $IDENT = serde_json::from_str(&res_text)?;
-            Ok(res_json)
-        }
-
-        impl $IDENT {
-            pub fn to_string(&self) -> String { serde_json::to_string(&self).unwrap() }
-        }
-
-        impl Display for $IDENT {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", self.to_string())
-            }
-        }
-    };
-}
 
 /// Runs the `$code` block after evaluating the `$eval` expression and assigning
 /// it to `$id`.

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,6 @@ allow = ["MIT", "Apache-2.0"]
 copyleft = "deny"
 
 exceptions = [
-    { name = "unicode-ident", allow = ["Unicode-DFS-2016"] }, 
-    { name = "encoding_rs", allow = ["BSD-3-Clause"] },
+    { name = "unicode-ident", allow = ["Unicode-DFS-2016"] },
     { name = "is_ci" , allow = ["ISC"] }
 ]


### PR DESCRIPTION
Remove the use of `reqwest` crate from the core code. Since the `encoding-rs` was dependent on the reqwest code and we were expecting an license exception for `enoding-rs`. But now we don't have reqwest, thus there is no encoding-rs in dependencies and can be safely removed from license exception.

Closes #140 