### PR TITLE
[tui] feature : Copy Selected text in TUI

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -86,6 +86,7 @@ r3bl_ansi_color = "0.6.7"
 
 # Terminal
 ansi_term = "0.12.1"
+clipboard = "0.5.0"
 
 [dev-dependencies]
 reedline = "0.16.0"

--- a/tui/src/tui/editor/editor_buffer/editor_buffer_clipboard_support.rs
+++ b/tui/src/tui/editor/editor_buffer/editor_buffer_clipboard_support.rs
@@ -1,0 +1,71 @@
+/*
+ *   Copyright (c) 2023 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+pub mod copy_to_clipboard {
+    use clipboard::{self, ClipboardContext, ClipboardProvider};
+    use r3bl_rs_utils_core::{call_if_true, log_debug, ChUnit};
+
+    use crate::*;
+    pub fn copy_selection(buffer: &mut EditorBuffer) {
+        let text = buffer.get_as_string(); // Get the entire text from the file
+        let selection_map = buffer.get_selection_map(); // Get the selection map
+
+        // Initialize an empty string to store the copied text
+        let mut copied_text = String::new();
+
+        let map = selection_map.map.clone();
+        let mut row_indexes: Vec<u16> = map.keys().map(|k| u16::from(k.value)).collect();
+        row_indexes.sort(); // Sort the RowIndex for sequential input.
+        let row_indexes: Vec<ChUnit> = row_indexes
+            .iter()
+            .map(|&x| r3bl_rs_utils_core::ChUnit::from(x))
+            .collect();
+
+        for row_idx in row_indexes {
+            if let Some(selection_range) = map.get(&row_idx) {
+                let start_idx =
+                    u16::from(selection_range.start_display_col_index) as usize;
+                let end_idx = u16::from(selection_range.end_display_col_index) as usize;
+                let row_idx = u16::from(row_idx.value) as usize;
+
+                // Extract the selected text for the current row
+                let selected_text = text
+                    .lines()
+                    .nth(row_idx)
+                    .and_then(|line| line.get(start_idx..end_idx))
+                    .unwrap_or("");
+                copied_text.push_str(selected_text);
+                copied_text.push('\n');
+            }
+        }
+        copy_to_clipboard(copied_text);
+    }
+
+    fn copy_to_clipboard(text_to_copy: String) {
+        // Create a clipboard context.
+        let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
+        // Copy the text to the clipboard.
+        ctx.set_contents(text_to_copy.to_owned()).unwrap();
+        call_if_true!(
+            DEBUG_TUI_COPY_PASTE,
+            log_debug(format!(
+                "\n🍕🍕🍕 Selected Text was copied: \n{}",
+                text_to_copy
+            ))
+        );
+    }
+}

--- a/tui/src/tui/editor/editor_buffer/editor_buffer_struct.rs
+++ b/tui/src/tui/editor/editor_buffer/editor_buffer_struct.rs
@@ -237,7 +237,7 @@ pub mod access_and_mutate {
                 .iter()
                 .map(|l| l.string.clone())
                 .collect::<Vec<String>>()
-                .join("\n")
+                .join(", ")
         }
 
         pub fn set_lines(&mut self, lines: Vec<String>) {

--- a/tui/src/tui/editor/editor_buffer/editor_buffer_struct.rs
+++ b/tui/src/tui/editor/editor_buffer/editor_buffer_struct.rs
@@ -237,7 +237,7 @@ pub mod access_and_mutate {
                 .iter()
                 .map(|l| l.string.clone())
                 .collect::<Vec<String>>()
-                .join(", ")
+                .join("\n")
         }
 
         pub fn set_lines(&mut self, lines: Vec<String>) {

--- a/tui/src/tui/editor/editor_buffer/mod.rs
+++ b/tui/src/tui/editor/editor_buffer/mod.rs
@@ -16,6 +16,7 @@
  */
 
 // Attach.
+pub mod editor_buffer_clipboard_support;
 pub mod editor_buffer_selection_support;
 pub mod editor_buffer_struct;
 pub mod selection_map;

--- a/tui/src/tui/editor/editor_component/editor_event.rs
+++ b/tui/src/tui/editor/editor_component/editor_event.rs
@@ -42,6 +42,7 @@ pub enum EditorEvent {
     MoveCaret(CaretDirection),
     Resize(Size),
     Select(SelectionScope),
+    Copy,
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -116,6 +117,12 @@ impl TryFrom<&InputEvent> for EditorEvent {
                 key: Key::SpecialKey(SpecialKey::End),
                 mask: ModifierKeysMask::SHIFT,
             }) => Ok(EditorEvent::Select(SelectionScope::End)),
+
+            //  Copying Events
+            InputEvent::Keyboard(KeyPress::WithModifiers {
+                key: Key::Character('c'),
+                mask: ModifierKeysMask::CTRL,
+            }) => Ok(EditorEvent::Copy),
 
             // Other events.
             InputEvent::Keyboard(KeyPress::Plain {
@@ -332,6 +339,10 @@ impl EditorEvent {
                     );
                 }
             },
+
+            EditorEvent::Copy => {
+                EditorEngineInternalApi::copy_selection(editor_buffer);
+            }
         };
     }
 

--- a/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
@@ -21,7 +21,7 @@ use get_size::GetSize;
 use r3bl_rs_utils_core::*;
 use serde::{Deserialize, Serialize};
 
-use crate::*;
+use crate::{editor_buffer_clipboard_support::copy_to_clipboard, *};
 
 /// Functions that implement the editor engine.
 pub struct EditorEngineInternalApi;
@@ -133,6 +133,10 @@ impl EditorEngineInternalApi {
         engine: &mut EditorEngine,
     ) -> Option<()> {
         content_mut::backspace_at_caret(buffer, engine)
+    }
+
+    pub fn copy_selection(buffer: &mut EditorBuffer) {
+        copy_to_clipboard::copy_selection(buffer)
     }
 }
 

--- a/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
@@ -135,7 +135,7 @@ impl EditorEngineInternalApi {
         content_mut::backspace_at_caret(buffer, engine)
     }
 
-    pub fn copy_selection(buffer: &mut EditorBuffer) {
+    pub fn copy_selection(buffer: &EditorBuffer) {
         copy_to_clipboard::copy_selection(buffer)
     }
 }


### PR DESCRIPTION
The PR comprises of changes required to implement the feature where we can copy the text to the clipboard from TUI. Here, We set in a logic which takes whole text and the `SelectionMap`. We then take the RowIndex in order and then based on it extract the selection caret values from all the lines(rows). Then we pass this to clipboard crate API to copy with our system clipboard.

Another minor change which have been made is for `get_as_string()` method for SelectionMap is now using join delimeter as a newline instead of comma.

![image](https://github.com/r3bl-org/r3bl_rs_utils/assets/79367883/052642b9-7fe8-4b68-8cd1-9407ecb25737)

The same text as seen in the image gets selected to the clipboard.

Closes #147 