### PR TITLE
[tui] Remove bitflags dep, so Cargo.toml can be upgraded to latest

### DIFF
--- a/run.nu
+++ b/run.nu
@@ -47,6 +47,8 @@ def main [...args: string] {
         "watch-all-tests" => {watch-all-tests}
         "watch-macro-expand-one-test" => {watch-macro-expand-one-test $args}
         "docs" => {docs}
+        "check" => {check}
+        "check-watch" => {check-watch}
         "clippy" => {clippy}
         "clippy-watch" => {clippy-watch}
         "rustfmt" => {rustfmt}
@@ -108,8 +110,6 @@ def watch-one-test [args: list<string>] {
         $user_input
     }
 
-
-
     if $folder_name != "" {
         cd $folder_name
     }
@@ -159,6 +159,8 @@ def print-help [command: string] {
         print $'    (ansi green)watch-one-test(ansi reset) (ansi blue_bold)<folder-name> (ansi blue_bold)<test-name>(ansi reset)'
         print $'    (ansi green)watch-all-tests(ansi reset)'
         print $'    (ansi green)watch-macro-expand-one-test(ansi reset) (ansi blue_bold)<test-name>(ansi reset)'
+        print $'    (ansi green)check(ansi reset)'
+        print $'    (ansi green)check-watch(ansi reset)'
         print $'    (ansi green)clippy(ansi reset)'
         print $'    (ansi green)clippy-watch(ansi reset)'
         print $'    (ansi green)serve-docs(ansi reset)'
@@ -224,15 +226,17 @@ def test [] {
     for folder in ($workspace_folders) {
         cd $folder
         print $'(ansi magenta)≡ Running tests in ($folder) .. ≡(ansi reset)'
-        cargo test -q -- --test-threads=4
+        cargo test -q -- --test-threads=20
         cd ..
     }
 }
 
-def clippy-watch [] {
-    cargo fix --allow-dirty --allow-staged
-    cargo fmt --all
-    cargo watch -x 'clippy --fix --allow-dirty --allow-staged' -c -q
+def check [] {
+    cargo check --workspace
+}
+
+def check-watch [] {
+    cargo watch -x 'check --workspace'
 }
 
 def clippy [] {
@@ -243,6 +247,12 @@ def clippy [] {
         cargo fmt --all
         cd ..
     }
+}
+
+def clippy-watch [] {
+    cargo fix --allow-dirty --allow-staged
+    cargo fmt --all
+    cargo watch -x 'clippy --fix --allow-dirty --allow-staged' -c -q
 }
 
 def docs [] {

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -44,9 +44,6 @@ futures = "0.3.28"
 crossterm = { version = "0.26.1", features = ["event-stream"] }
 futures-util = "0.3.28"
 
-# Bitflags.
-bitflags = "1.3.2"
-
 # https://github.com/serde-rs/serde.
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tui/examples/demo/ex_editor/app.rs
+++ b/tui/examples/demo/ex_editor/app.rs
@@ -150,7 +150,9 @@ mod app_with_layout_impl_trait_app {
             .await
         }
 
-        fn init(&mut self) { populate_component_registry::init(self); }
+        fn init(&mut self) {
+            populate_component_registry::init(self);
+        }
 
         fn get_component_registry(&mut self) -> &mut ComponentRegistry<State, Action> {
             &mut self.component_registry
@@ -180,7 +182,7 @@ mod detect_modal_dialog_activation_from_input_event {
                 input_event,
                 KeyPress::WithModifiers {
                     key: Key::Character('l'),
-                    mask: ModifierKeysMask::CTRL,
+                    mask: ModifierKeysMask::new().with_ctrl(),
                 },
             ) {
                 // Reset the dialog component prior to activating / showing it.
@@ -211,7 +213,7 @@ mod detect_modal_dialog_activation_from_input_event {
                 input_event,
                 KeyPress::WithModifiers {
                     key: Key::Character('k'),
-                    mask: ModifierKeysMask::CTRL,
+                    mask: ModifierKeysMask::new().with_ctrl(),
                 },
             ) {
                 // Reset the dialog component prior to activating / showing it.

--- a/tui/examples/demo/ex_editor/launcher.rs
+++ b/tui/examples/demo/ex_editor/launcher.rs
@@ -37,7 +37,7 @@ pub async fn run_app() -> CommonResult<()> {
 
         // Exit if these keys are pressed.
         let exit_keys: Vec<InputEvent> = vec![InputEvent::Keyboard(
-            keypress! { @char ModifierKeysMask::CTRL, 'x' },
+            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'x' },
         )];
 
         // Create a window.

--- a/tui/examples/demo/ex_pitch/app.rs
+++ b/tui/examples/demo/ex_pitch/app.rs
@@ -120,7 +120,7 @@ mod app_with_layout_impl_trait_app {
             // Ctrl + n => next slide.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('n'),
-                mask: ModifierKeysMask::CTRL,
+                mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 // Spawn next slide action.
                 spawn_dispatch_action!(args.shared_store, Action::SlideControlNextSlide);
@@ -130,7 +130,7 @@ mod app_with_layout_impl_trait_app {
             // Ctrl + p => previous slide.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('p'),
-                mask: ModifierKeysMask::CTRL,
+                mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 // Spawn previous slide action.
                 spawn_dispatch_action!(
@@ -152,7 +152,9 @@ mod app_with_layout_impl_trait_app {
             .await
         }
 
-        fn init(&mut self) { populate_component_registry::init(self); }
+        fn init(&mut self) {
+            populate_component_registry::init(self);
+        }
 
         fn get_component_registry(&mut self) -> &mut ComponentRegistry<State, Action> {
             &mut self.component_registry

--- a/tui/examples/demo/ex_pitch/launcher.rs
+++ b/tui/examples/demo/ex_pitch/launcher.rs
@@ -37,7 +37,7 @@ pub async fn run_app() -> CommonResult<()> {
 
         // Exit if these keys are pressed.
         let exit_keys: Vec<InputEvent> = vec![InputEvent::Keyboard(
-            keypress! { @char ModifierKeysMask::CTRL, 'x' },
+            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'x' },
         )];
 
         // Create a window.

--- a/tui/examples/demo/ex_rc/app.rs
+++ b/tui/examples/demo/ex_rc/app.rs
@@ -155,7 +155,7 @@ mod app_with_layout_impl_trait_app {
             // Ctrl + n => next slide.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('n'),
-                mask: ModifierKeysMask::CTRL,
+                mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 // Spawn next slide action.
                 spawn_dispatch_action!(args.shared_store, Action::SlideControlNextSlide);
@@ -165,7 +165,7 @@ mod app_with_layout_impl_trait_app {
             // Ctrl + p => previous slide.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('p'),
-                mask: ModifierKeysMask::CTRL,
+                mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 // Spawn previous slide action.
                 spawn_dispatch_action!(
@@ -178,7 +178,7 @@ mod app_with_layout_impl_trait_app {
             // x => Cancel animation & don't consume the event.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('x'),
-                mask: ModifierKeysMask::CTRL,
+                mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 self.animator.stop();
             };

--- a/tui/examples/demo/ex_rc/launcher.rs
+++ b/tui/examples/demo/ex_rc/launcher.rs
@@ -37,7 +37,7 @@ pub async fn run_app() -> CommonResult<()> {
 
         // Exit if these keys are pressed.
         let exit_keys: Vec<InputEvent> = vec![InputEvent::Keyboard(
-            keypress! { @char ModifierKeysMask::CTRL, 'x' },
+            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'x' },
         )];
 
         // Create a window.

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -186,7 +186,7 @@
 //! cargo run --release --example demo
 //! ```
 //!
-//! > [!NOTE] Linux users might need to install [libxcb](https://xcb.freedesktop.org/) in order to use
+//! > Linux users might need to install [libxcb](https://xcb.freedesktop.org/) in order to use
 //! > copy/paste commands on X11.
 //! > [More info](https://github.com/aweinstock314/rust-clipboard/issues/67).
 //! >

--- a/tui/src/tui/dialog/dialog_component/dialog_event.rs
+++ b/tui/src/tui/dialog/dialog_component/dialog_event.rs
@@ -100,7 +100,7 @@ mod test_dialog_event {
 
     #[test]
     fn dialog_event_handles_modal_keypress() {
-        let modal_keypress = keypress!(@char ModifierKeysMask::CTRL, 'l');
+        let modal_keypress = keypress!(@char ModifierKeysMask::new().with_ctrl(), 'l');
         let input_event = InputEvent::Keyboard(modal_keypress);
         let dialog_event =
             DialogEvent::should_activate_modal(&input_event, modal_keypress);

--- a/tui/src/tui/editor/editor_component/editor_event.rs
+++ b/tui/src/tui/editor/editor_component/editor_event.rs
@@ -81,53 +81,103 @@ impl TryFrom<&InputEvent> for EditorEvent {
             // Selection events.
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::Right),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::OneCharRight)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::Left),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::OneCharLeft)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::Down),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::OneLineDown)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::Up),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::OneLineUp)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::PageUp),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::PageUp)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::PageDown),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::PageDown)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::Home),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::Home)),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::End),
-                mask: ModifierKeysMask::SHIFT,
+                mask:
+                    ModifierKeysMask {
+                        shift_key_state: KeyState::Pressed,
+                        ctrl_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Select(SelectionScope::End)),
 
             //  Clipboard events.
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::Character('c'),
-                mask: ModifierKeysMask::CTRL,
+                mask:
+                    ModifierKeysMask {
+                        ctrl_key_state: KeyState::Pressed,
+                        shift_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Copy),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::Character('v'),
-                mask: ModifierKeysMask::CTRL,
+                mask:
+                    ModifierKeysMask {
+                        ctrl_key_state: KeyState::Pressed,
+                        shift_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
             }) => Ok(EditorEvent::Paste),
 
             // Other events.
@@ -180,6 +230,7 @@ impl TryFrom<&InputEvent> for EditorEvent {
             InputEvent::Keyboard(KeyPress::Plain {
                 key: Key::SpecialKey(SpecialKey::Right),
             }) => Ok(Self::MoveCaret(CaretDirection::Right)),
+
             _ => Err(format!("Invalid input event: {input_event:?}")),
         }
     }

--- a/tui/src/tui/terminal_lib_backends/keypress.rs
+++ b/tui/src/tui/terminal_lib_backends/keypress.rs
@@ -31,10 +31,13 @@ use crate::*;
 ///     key: Key::Character('a'),
 ///   };
 ///
-///   let alt_a = keypress!(@char ModifierKeysMask::ALT, 'a');
+///   let alt_a = keypress!(@char ModifierKeysMask::new().with_alt(), 'a');
 ///   let alt_a = KeyPress::WithModifiers {
 ///     key: Key::Character('a'),
-///     mask: ModifierKeysMask::ALT,
+///     mask: ModifierKeysMask {
+///         alt_key_state: KeyState::Pressed,
+///         ..Default::default()
+///     },
 ///   };
 ///
 ///   let enter = keypress!(@special SpecialKey::Enter);
@@ -42,10 +45,13 @@ use crate::*;
 ///     key: Key::SpecialKey(SpecialKey::Enter),
 ///   };
 ///
-///   let alt_enter = keypress!(@special ModifierKeysMask::ALT, SpecialKey::Enter);
+///   let alt_enter = keypress!(@special ModifierKeysMask::new().with_alt(), SpecialKey::Enter);
 ///   let alt_enter = KeyPress::WithModifiers {
 ///     key: Key::SpecialKey(SpecialKey::Enter),
-///     mask: ModifierKeysMask::ALT,
+///     mask: ModifierKeysMask {
+///         alt_key_state: KeyState::Pressed,
+///         ..Default::default()
+///     }
 ///   };
 /// }
 /// ```

--- a/tui/src/tui/terminal_lib_backends/modifier_keys_mask.rs
+++ b/tui/src/tui/terminal_lib_backends/modifier_keys_mask.rs
@@ -15,22 +15,120 @@
  *   limitations under the License.
  */
 
-use bitflags::bitflags;
 use crossterm::event::*;
+use get_size::GetSize;
 use serde::{Deserialize, Serialize};
 
-bitflags! {
-    #[derive(Serialize, Deserialize)]
-    pub struct ModifierKeysMask: u8 {
-        const SHIFT = 0b0000_0001;
-        const CTRL  = 0b0000_0010;
-        const ALT   = 0b0000_0100;
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, GetSize, PartialEq, Eq, Default)]
+pub struct ModifierKeysMask {
+    pub shift_key_state: KeyState,
+    pub ctrl_key_state: KeyState,
+    pub alt_key_state: KeyState,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, GetSize, PartialEq, Eq, Default)]
+pub enum KeyState {
+    Pressed,
+    #[default]
+    NotPressed,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, GetSize, PartialEq, Eq)]
+
+pub enum MatchResult {
+    Matches,
+    DoesNotMatch,
+}
+
+impl From<bool> for MatchResult {
+    fn from(other: bool) -> Self {
+        if other {
+            MatchResult::Matches
+        } else {
+            MatchResult::DoesNotMatch
+        }
+    }
+}
+
+impl ModifierKeysMask {
+    pub fn with_shift(mut self) -> Self {
+        self.shift_key_state = KeyState::Pressed;
+        self
+    }
+
+    pub fn with_ctrl(mut self) -> Self {
+        self.ctrl_key_state = KeyState::Pressed;
+        self
+    }
+
+    pub fn with_alt(mut self) -> Self {
+        self.alt_key_state = KeyState::Pressed;
+        self
+    }
+
+    pub fn new() -> Self {
+        ModifierKeysMask {
+            shift_key_state: KeyState::NotPressed,
+            ctrl_key_state: KeyState::NotPressed,
+            alt_key_state: KeyState::NotPressed,
+        }
+    }
+
+    /// Check `other` for
+    /// [crossterm::event::KeyModifiers](crossterm::event::KeyModifiers::SHIFT) bit.
+    /// Check `other` for `CONTROL` bit. Check `other` for `ALT` bit. If all bits
+    /// match `self` then return `true`, otherwise return `false`.
+    ///
+    /// Difference in meaning between `intersects` and `contains`:
+    /// - `intersects` -> means that the given bit shows up in your variable, but it
+    ///   might contain other bits.
+    /// - `contains` -> means that your variable ONLY contains these bits.
+    /// - Docs: <https://docs.rs/bitflags/latest/bitflags/index.html>
+    pub fn matches(&self, other: KeyModifiers) -> MatchResult {
+        match (
+            other.intersects(KeyModifiers::SHIFT),
+            other.intersects(KeyModifiers::CONTROL),
+            other.intersects(KeyModifiers::ALT),
+        ) {
+            (true, true, true) => (self.shift_key_state == KeyState::Pressed
+                && self.ctrl_key_state == KeyState::Pressed
+                && self.alt_key_state == KeyState::Pressed)
+                .into(),
+            (true, true, false) => (self.shift_key_state == KeyState::Pressed
+                && self.ctrl_key_state == KeyState::Pressed
+                && self.alt_key_state == KeyState::NotPressed)
+                .into(),
+            (true, false, true) => (self.shift_key_state == KeyState::Pressed
+                && self.ctrl_key_state == KeyState::NotPressed
+                && self.alt_key_state == KeyState::Pressed)
+                .into(),
+            (true, false, false) => (self.shift_key_state == KeyState::Pressed
+                && self.ctrl_key_state == KeyState::NotPressed
+                && self.alt_key_state == KeyState::NotPressed)
+                .into(),
+            (false, true, true) => (self.shift_key_state == KeyState::NotPressed
+                && self.ctrl_key_state == KeyState::Pressed
+                && self.alt_key_state == KeyState::Pressed)
+                .into(),
+            (false, true, false) => (self.shift_key_state == KeyState::NotPressed
+                && self.ctrl_key_state == KeyState::Pressed
+                && self.alt_key_state == KeyState::NotPressed)
+                .into(),
+            (false, false, true) => (self.shift_key_state == KeyState::NotPressed
+                && self.ctrl_key_state == KeyState::NotPressed
+                && self.alt_key_state == KeyState::Pressed)
+                .into(),
+            (false, false, false) => (self.shift_key_state == KeyState::NotPressed
+                && self.ctrl_key_state == KeyState::NotPressed
+                && self.alt_key_state == KeyState::NotPressed)
+                .into(),
+        }
     }
 }
 
 pub fn convert_key_modifiers(modifiers: &KeyModifiers) -> Option<ModifierKeysMask> {
     // Start w/ empty my_modifiers.
-    let my_modifiers: ModifierKeysMask = (*modifiers).into();
+    let my_modifiers = ModifierKeysMask::from(*modifiers);
     if modifiers.is_empty() {
         None
     } else {
@@ -44,49 +142,177 @@ impl From<KeyModifiers> for ModifierKeysMask {
     ///   other bits.
     /// - `contains` -> means that your variable ONLY contains these bits.
     /// - Docs: <https://docs.rs/bitflags/latest/bitflags/index.html>
-    fn from(other: KeyModifiers) -> Self {
+    fn from(other: KeyModifiers) -> ModifierKeysMask {
         // Start w/ empty my_modifiers.
-        let mut my_modifiers: ModifierKeysMask = ModifierKeysMask::empty(); // 0b0000_0000
+        let mut it: ModifierKeysMask = ModifierKeysMask {
+            shift_key_state: KeyState::NotPressed,
+            ctrl_key_state: KeyState::NotPressed,
+            alt_key_state: KeyState::NotPressed,
+        };
 
         // Try and set any bitflags from key_event.
         if other.intersects(KeyModifiers::SHIFT) {
-            my_modifiers.insert(ModifierKeysMask::SHIFT) // my_modifiers = 0b0000_0001;
+            it.shift_key_state = KeyState::Pressed;
         }
         if other.intersects(KeyModifiers::CONTROL) {
-            my_modifiers.insert(ModifierKeysMask::CTRL) // my_modifiers = 0b0000_0010;
+            it.ctrl_key_state = KeyState::Pressed;
         }
         if other.intersects(KeyModifiers::ALT) {
-            my_modifiers.insert(ModifierKeysMask::ALT) // my_modifiers = 0b0000_0100;
+            it.alt_key_state = KeyState::Pressed;
         }
 
-        my_modifiers
+        it
     }
 }
 
 #[cfg(test)]
-mod test_bitflags {
-    use bitflags::bitflags;
+mod rs_modifier_keys_mask_tests {
+    use r3bl_rs_utils_core::assert_eq2;
+
+    use super::*;
 
     #[test]
-    fn bitflags_test() {
-        bitflags! {
-            struct TestFlags: u8 {
-                const SHIFT = 0b0000_0001;
-                const CTRL  = 0b0000_0010;
-                const ALT   = 0b0000_0100;
-            }
-        }
+    fn test_empty_mask() {
+        let mask = ModifierKeysMask::new();
 
-        let mut my_flags: TestFlags = TestFlags::empty(); // 0b0000_0000
-        my_flags.insert(TestFlags::SHIFT); // my_flags = 0b0000_0001;
-        my_flags.insert(TestFlags::CTRL); // my_flags = 0b0000_0011;
+        assert_eq2!(mask.shift_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.alt_key_state, KeyState::NotPressed);
 
-        assert!(my_flags.contains(TestFlags::SHIFT));
-        assert!(my_flags.contains(TestFlags::CTRL));
-        assert!(!my_flags.contains(TestFlags::ALT));
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+    }
 
-        assert!(my_flags.intersects(TestFlags::SHIFT));
-        assert!(my_flags.intersects(TestFlags::CTRL));
-        assert!(!my_flags.intersects(TestFlags::ALT));
+    #[test]
+    fn test_shift_mask() {
+        let mask = ModifierKeysMask::new().with_shift();
+
+        assert_eq2!(mask.shift_key_state, KeyState::Pressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.alt_key_state, KeyState::NotPressed);
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::Matches);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+    }
+
+    #[test]
+    fn test_ctrl_mask() {
+        let mask = ModifierKeysMask::new().with_ctrl();
+
+        assert_eq2!(mask.shift_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::Pressed);
+        assert_eq2!(mask.alt_key_state, KeyState::NotPressed);
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(mask.matches(KeyModifiers::CONTROL), MatchResult::Matches);
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+    }
+
+    #[test]
+    fn test_alt_mask() {
+        let mask = ModifierKeysMask::new().with_alt();
+
+        assert_eq2!(mask.shift_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.alt_key_state, KeyState::Pressed);
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::Matches);
+    }
+
+    #[test]
+    fn test_shift_ctrl_mask() {
+        let mask = ModifierKeysMask::new().with_shift().with_ctrl();
+
+        assert_eq2!(mask.shift_key_state, KeyState::Pressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::Pressed);
+        assert_eq2!(mask.alt_key_state, KeyState::NotPressed);
+
+        assert_eq2!(
+            mask.matches(KeyModifiers::SHIFT | KeyModifiers::CONTROL),
+            MatchResult::Matches
+        );
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+    }
+
+    #[test]
+    fn test_shift_alt_mask() {
+        let mask = ModifierKeysMask::new().with_shift().with_alt();
+
+        assert_eq2!(mask.shift_key_state, KeyState::Pressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.alt_key_state, KeyState::Pressed);
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+
+        assert_eq2!(
+            mask.matches(KeyModifiers::SHIFT | KeyModifiers::ALT),
+            MatchResult::Matches
+        );
+    }
+
+    #[test]
+    fn test_ctrl_alt_mask() {
+        let mask = ModifierKeysMask::new().with_ctrl().with_alt();
+
+        assert_eq2!(mask.shift_key_state, KeyState::NotPressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::Pressed);
+        assert_eq2!(mask.alt_key_state, KeyState::Pressed);
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL | KeyModifiers::ALT),
+            MatchResult::Matches
+        );
+    }
+
+    #[test]
+    fn test_shift_ctrl_alt_mask() {
+        let mask = ModifierKeysMask::new().with_shift().with_ctrl().with_alt();
+
+        assert_eq2!(mask.shift_key_state, KeyState::Pressed);
+        assert_eq2!(mask.ctrl_key_state, KeyState::Pressed);
+        assert_eq2!(mask.alt_key_state, KeyState::Pressed);
+
+        assert_eq2!(mask.matches(KeyModifiers::SHIFT), MatchResult::DoesNotMatch);
+        assert_eq2!(
+            mask.matches(KeyModifiers::CONTROL),
+            MatchResult::DoesNotMatch
+        );
+        assert_eq2!(mask.matches(KeyModifiers::ALT), MatchResult::DoesNotMatch);
+
+        assert_eq2!(
+            mask.matches(KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::ALT),
+            MatchResult::Matches
+        );
     }
 }

--- a/tui/src/tui/terminal_lib_backends/test_input_event.rs
+++ b/tui/src/tui/terminal_lib_backends/test_input_event.rs
@@ -96,9 +96,7 @@ mod tests {
             };
             let maybe_modifier_keys = convert_key_modifiers(&key_event.modifiers);
             assert!(maybe_modifier_keys.is_some());
-            assert!(maybe_modifier_keys
-                .unwrap()
-                .contains(ModifierKeysMask::CTRL));
+            assert!(maybe_modifier_keys.unwrap() == ModifierKeysMask::new().with_ctrl());
         }
         // "Ctrl + Shift + X"
         {
@@ -108,9 +106,10 @@ mod tests {
             };
             let maybe_modifier_keys = convert_key_modifiers(&key_event.modifiers);
             assert!(maybe_modifier_keys.is_some());
-            assert!(maybe_modifier_keys
-                .unwrap()
-                .contains(ModifierKeysMask::CTRL | ModifierKeysMask::SHIFT));
+            assert!(
+                maybe_modifier_keys.unwrap()
+                    == (ModifierKeysMask::new().with_ctrl().with_shift())
+            );
         }
         // "Ctrl + Shift + Alt + X"
         {
@@ -120,9 +119,10 @@ mod tests {
             };
             let maybe_modifier_keys = convert_key_modifiers(&key_event.modifiers);
             assert!(maybe_modifier_keys.is_some());
-            assert!(maybe_modifier_keys.unwrap().contains(
-                ModifierKeysMask::CTRL | ModifierKeysMask::SHIFT | ModifierKeysMask::ALT
-            ));
+            assert!(
+                maybe_modifier_keys.unwrap()
+                    == ModifierKeysMask::new().with_alt().with_ctrl().with_shift()
+            );
         }
     }
 

--- a/tui/src/tui/terminal_lib_backends/test_keypress.rs
+++ b/tui/src/tui/terminal_lib_backends/test_keypress.rs
@@ -36,10 +36,10 @@ mod tests {
         // With modifier.
         {
             let macro_syntax =
-                keypress! { @char ModifierKeysMask::SHIFT | ModifierKeysMask::CTRL, 'a' };
+                keypress! { @char ModifierKeysMask::new().with_shift().with_ctrl(), 'a' };
             let struct_syntax = KeyPress::WithModifiers {
                 key: Key::Character('a'),
-                mask: ModifierKeysMask::SHIFT | ModifierKeysMask::CTRL,
+                mask: ModifierKeysMask::new().with_shift().with_ctrl(),
             };
             assert_eq2!(macro_syntax, struct_syntax);
         }
@@ -57,10 +57,10 @@ mod tests {
         }
         // With modifier.
         {
-            let macro_syntax = keypress! { @special ModifierKeysMask::CTRL | ModifierKeysMask::ALT, SpecialKey::Left };
+            let macro_syntax = keypress! { @special ModifierKeysMask::new().with_alt().with_ctrl(), SpecialKey::Left };
             let struct_syntax = KeyPress::WithModifiers {
                 key: Key::SpecialKey(SpecialKey::Left),
-                mask: ModifierKeysMask::CTRL | ModifierKeysMask::ALT,
+                mask: ModifierKeysMask::new().with_alt().with_ctrl(),
             };
             assert_eq2!(macro_syntax, struct_syntax);
         }
@@ -78,10 +78,11 @@ mod tests {
         }
         // With modifier.
         {
-            let macro_syntax = keypress! { @fn ModifierKeysMask::SHIFT, FunctionKey::F1 };
+            let macro_syntax =
+                keypress! { @fn ModifierKeysMask::new().with_shift(), FunctionKey::F1 };
             let struct_syntax = KeyPress::WithModifiers {
                 key: Key::FunctionKey(FunctionKey::F1),
-                mask: ModifierKeysMask::SHIFT,
+                mask: ModifierKeysMask::new().with_shift(),
             };
             assert_eq2!(macro_syntax, struct_syntax);
         }
@@ -110,7 +111,7 @@ mod tests {
             assert_eq2!(
                 converted_keypress,
                 KeyPress::WithModifiers {
-                    mask: ModifierKeysMask::CTRL,
+                    mask: ModifierKeysMask::new().with_ctrl(),
                     key: Key::Character('x'),
                 }
             );
@@ -126,7 +127,7 @@ mod tests {
             assert_eq2!(
                 converted_keypress,
                 KeyPress::WithModifiers {
-                    mask: ModifierKeysMask::CTRL | ModifierKeysMask::ALT,
+                    mask: ModifierKeysMask::new().with_alt().with_ctrl(),
                     key: Key::Character('x'),
                 }
             );

--- a/tui/src/tui/terminal_lib_backends/test_mouse_input.rs
+++ b/tui/src/tui/terminal_lib_backends/test_mouse_input.rs
@@ -40,7 +40,7 @@ mod tests {
             );
             assert_eq2!(
                 converted_mouse_input.maybe_modifier_keys,
-                Some(ModifierKeysMask::SHIFT)
+                Some(ModifierKeysMask::new().with_shift())
             );
         }
         // Mouse moved.
@@ -133,7 +133,7 @@ mod tests {
             );
             assert_eq2!(
                 converted_mouse_input.maybe_modifier_keys,
-                Some(ModifierKeysMask::SHIFT)
+                Some(ModifierKeysMask::new().with_shift())
             );
         }
         // Mouse up.
@@ -195,7 +195,7 @@ mod tests {
             );
             assert_eq2!(
                 converted_mouse_input.maybe_modifier_keys,
-                Some(ModifierKeysMask::SHIFT | ModifierKeysMask::ALT)
+                Some(ModifierKeysMask::new().with_alt().with_shift())
             );
         }
     }


### PR DESCRIPTION
The latest bitflags crate breaks things for modifier_keys_mask.rs.
So drop this depenedency so that Cargo.toml can be upgraded to the
latest of each dep.

Fixes: #161