### PR TITLE
Nazmulidris/cleanup-colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - [v0.9.5 2023-10-14](#v095-2023-10-14)
   - [v0.9.1 2023-03-06](#v091-2023-03-06)
 - [r3bl_tuify](#r3bl_tuify)
+  - [v0.1.20 2023-10-21](#v0120-2023-10-21)
   - [v0.1.19 2023-10-17](#v0119-2023-10-17)
   - [v0.1.18 2023-10-17](#v0118-2023-10-17)
   - [v0.1.17 2023-10-14](#v0117-2023-10-14)
@@ -25,6 +26,7 @@
   - [v0.2.5 2023-10-17](#v025-2023-10-17)
   - [v0.2.4 2023-10-14](#v024-2023-10-14)
 - [r3bl_tui](#r3bl_tui)
+  - [Next release](#next-release)
   - [v0.3.6 2023-10-17](#v036-2023-10-17)
   - [v0.3.5 2023-10-14](#v035-2023-10-14)
   - [v0.3.3 2023-04-20](#v033-2023-04-20)
@@ -136,6 +138,7 @@
 <a id="markdown-r3bl_tuify" name="r3bl_tuify"></a>
 
 ### v0.1.20 (2023-10-21)
+<a id="markdown-v0.1.20-2023-10-21" name="v0.1.20-2023-10-21"></a>
 
 - Updated:
   - Bug fix: <https://github.com/r3bl-org/r3bl_rs_utils/issues/170>
@@ -206,6 +209,13 @@
 
 ## `r3bl_tui`
 <a id="markdown-r3bl_tui" name="r3bl_tui"></a>
+
+### Next release
+<a id="markdown-next-release" name="next-release"></a>
+
+- Changed:
+  - Drop support for `palette` crate. Use `colorgrad` instead. More info here:
+    <https://github.com/r3bl-org/r3bl_rs_utils/issues/162>
 
 ### v0.3.6 (2023-10-17)
 <a id="markdown-v0.3.6-2023-10-17" name="v0.3.6-2023-10-17"></a>

--- a/ansi_color/examples/main.rs
+++ b/ansi_color/examples/main.rs
@@ -48,34 +48,40 @@ fn main() {
 
     // Set the color support override to ANSI 256 color mode.
     {
-        color_support_override_set(ColorSupport::Ansi256);
-        let msg: String =
-            format!("> Force ANSI 256 color mode ({:?})", detect_color_support());
+        global_color_support::set_override(ColorSupport::Ansi256);
+        let msg: String = format!(
+            "> Force ANSI 256 color mode ({:?})",
+            global_color_support::detect()
+        );
         print_text(&msg);
     }
 
     // Set the color support override to truecolor mode.
     {
-        color_support_override_set(ColorSupport::Truecolor);
-        let msg: String =
-            format!("> Force True color mode ({:?})", detect_color_support());
+        global_color_support::set_override(ColorSupport::Truecolor);
+        let msg: String = format!(
+            "> Force True color mode ({:?})",
+            global_color_support::detect()
+        );
         print_text(&msg);
     }
 
     // Set the color support override to grayscale mode.
     {
-        color_support_override_set(ColorSupport::Grayscale);
-        let msg: String =
-            format!("> Force Grayscale color mode ({:?})", detect_color_support());
+        global_color_support::set_override(ColorSupport::Grayscale);
+        let msg: String = format!(
+            "> Force Grayscale color mode ({:?})",
+            global_color_support::detect()
+        );
         print_text(&msg);
     }
 
     // Use runtime detection to determine the color support.
     {
-        color_support_override_set(ColorSupport::NotSet);
+        global_color_support::clear_override();
         let msg = format!(
             "> Runtime detection of color support ({:?})",
-            detect_color_support()
+            global_color_support::detect()
         );
         print_text(&msg);
     }

--- a/ansi_color/src/ansi_styled_text.rs
+++ b/ansi_color/src/ansi_styled_text.rs
@@ -78,7 +78,7 @@ mod style_impl {
     use std::fmt::{Display, Formatter, Result};
 
     use crate::{
-        detect_color_support, Color, ColorSupport, RgbColor, SgrCode, Style,
+        global_color_support, Color, ColorSupport, RgbColor, SgrCode, Style,
         TransformColor,
     };
 
@@ -89,7 +89,7 @@ mod style_impl {
     }
 
     fn fmt_color(color: Color, color_kind: ColorKind, f: &mut Formatter<'_>) -> Result {
-        match detect_color_support() {
+        match global_color_support::detect() {
             ColorSupport::Ansi256 => {
                 // ANSI 256 color mode.
                 let color = color.as_ansi256();
@@ -182,7 +182,7 @@ mod display_trait_impl {
         #[serial]
         #[test]
         fn test_formatted_string_creation_ansi256() -> Result<(), String> {
-            color_support_override_set(ColorSupport::Ansi256);
+            global_color_support::set_override(ColorSupport::Ansi256);
             let eg_1 = AnsiStyledText {
                 text: "Hello",
                 style: &[
@@ -217,7 +217,7 @@ mod display_trait_impl {
         #[serial]
         #[test]
         fn test_formatted_string_creation_truecolor() -> Result<(), String> {
-            color_support_override_set(ColorSupport::Truecolor);
+            global_color_support::set_override(ColorSupport::Truecolor);
             let eg_1 = AnsiStyledText {
                 text: "Hello",
                 style: &[
@@ -252,7 +252,7 @@ mod display_trait_impl {
         #[serial]
         #[test]
         fn test_formatted_string_creation_grayscale() -> Result<(), String> {
-            color_support_override_set(ColorSupport::Grayscale);
+            global_color_support::set_override(ColorSupport::Grayscale);
             let eg_1 = AnsiStyledText {
                 text: "Hello",
                 style: &[

--- a/ansi_color/src/convert.rs
+++ b/ansi_color/src/convert.rs
@@ -41,6 +41,7 @@ pub mod color_utils {
         }
     }
 
+    /// More info: <https://goodcalculators.com/rgb-to-grayscale-conversion-calculator/>
     pub fn convert_grayscale(color: (u8, u8, u8)) -> (u8, u8, u8) {
         // See https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale
         const SCALE: f64 = 256.0;

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -62,7 +62,7 @@ syntect = "5.0.0"
 nom = "7.1.3"
 
 # color gradients.
-palette = "0.6.1"
+colorgrad = "0.6.2"
 
 # Terminal.
 is-terminal = "0.4.7"

--- a/tui/src/tui/color_wheel/color_wheel_struct.rs
+++ b/tui/src/tui/color_wheel/color_wheel_struct.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 
 use get_size::GetSize;
 use palette::{Gradient, LinSrgb};
-use r3bl_ansi_color::{detect_color_support, ColorSupport};
+use r3bl_ansi_color::{global_color_support, ColorSupport};
 use r3bl_rs_utils_core::*;
 use rand::Rng;
 use serde::*;
@@ -61,7 +61,7 @@ impl ColorWheelConfig {
     pub fn narrow_config_based_on_color_support(
         configs: &[ColorWheelConfig],
     ) -> ColorWheelConfig {
-        let color_support = detect_color_support();
+        let color_support = global_color_support::detect();
         match color_support {
             // 1. If truecolor is supported, try and find a truecolor config.
             // 2. If not found, then look for an ANSI 256 config.
@@ -196,8 +196,8 @@ impl ColorWheel {
     /// 1. `configs`: A list of color wheel configs. The order of the configs is not
     ///    important. However, at the very least, one Truecolor config & one ANSI 256
     ///    config should be provided. The fallback is always grayscale. See
-    ///    [get_config_based_on_color_support](ColorWheelConfig::narrow_config_based_on_color_support),
-    ///    [r3bl_ansi_color::detect_color_support()] for more info.
+    ///    [ColorWheelConfig::narrow_config_based_on_color_support],
+    ///    [global_color_support::detect] for more info.
     pub fn new(configs: Vec<ColorWheelConfig>) -> Self {
         Self {
             configs,
@@ -716,7 +716,7 @@ impl ColorWheel {
 
 #[cfg(test)]
 mod tests_color_wheel_rgb {
-    use r3bl_ansi_color::{color_support_override_set, ColorSupport};
+    use r3bl_ansi_color::ColorSupport;
     use serial_test::serial;
 
     use super::*;
@@ -758,7 +758,7 @@ mod tests_color_wheel_rgb {
 
         // Set ColorSupport override to: Ansi 256.
         {
-            color_support_override_set(ColorSupport::Ansi256);
+            global_color_support::set_override(ColorSupport::Ansi256);
             let config = ColorWheelConfig::narrow_config_based_on_color_support(configs);
             assert_eq2!(
                 config,
@@ -767,12 +767,12 @@ mod tests_color_wheel_rgb {
                     ColorWheelSpeed::Medium,
                 ),
             );
-            color_support_override_set(ColorSupport::NotSet);
+            global_color_support::clear_override()
         }
 
         // Set ColorSupport override to: Truecolor.
         {
-            color_support_override_set(ColorSupport::Truecolor);
+            global_color_support::set_override(ColorSupport::Truecolor);
             let config = ColorWheelConfig::narrow_config_based_on_color_support(configs);
             assert_eq2!(
                 config,
@@ -782,12 +782,12 @@ mod tests_color_wheel_rgb {
                     Defaults::Steps as usize,
                 ),
             );
-            color_support_override_set(ColorSupport::NotSet);
+            global_color_support::clear_override()
         }
 
         // Set ColorSupport override to: Grayscale.
         {
-            color_support_override_set(ColorSupport::Grayscale);
+            global_color_support::set_override(ColorSupport::Grayscale);
             let config = ColorWheelConfig::narrow_config_based_on_color_support(configs);
             assert_eq2!(
                 config,
@@ -796,12 +796,12 @@ mod tests_color_wheel_rgb {
                     ColorWheelSpeed::Medium,
                 ),
             );
-            color_support_override_set(ColorSupport::NotSet);
+            global_color_support::clear_override()
         }
     }
 
     fn test_color_wheel_iterator() {
-        color_support_override_set(ColorSupport::Truecolor);
+        global_color_support::set_override(ColorSupport::Truecolor);
 
         let color_wheel = &mut test_helpers::create_color_wheel_rgb();
 
@@ -896,13 +896,13 @@ mod tests_color_wheel_rgb {
             TuiColor::Rgb(RgbValue::from_u8(28, 28, 28))
         );
 
-        color_support_override_set(ColorSupport::NotSet);
+        global_color_support::clear_override()
     }
 
     fn test_colorize_into_styled_texts_color_each_word() {
         let color_wheel_rgb = &mut test_helpers::create_color_wheel_rgb();
 
-        color_support_override_set(ColorSupport::Truecolor);
+        global_color_support::set_override(ColorSupport::Truecolor);
 
         let unicode_string = UnicodeString::from("HELLO WORLD");
 
@@ -933,7 +933,7 @@ mod tests_color_wheel_rgb {
             Some(TuiColor::Rgb(RgbValue::from_u8(0, 0, 0)))
         );
 
-        color_support_override_set(ColorSupport::NotSet);
+        global_color_support::clear_override()
     }
 
     fn test_colorize_to_styled_texts_color_each_character() {
@@ -941,7 +941,7 @@ mod tests_color_wheel_rgb {
 
         let color_wheel_rgb = &mut test_helpers::create_color_wheel_rgb();
 
-        color_support_override_set(ColorSupport::Truecolor);
+        global_color_support::set_override(ColorSupport::Truecolor);
 
         let unicode_string = UnicodeString::from("HELLO");
 
@@ -991,6 +991,6 @@ mod tests_color_wheel_rgb {
             Some(TuiColor::Rgb(RgbValue::from_u8(127, 127, 127)))
         );
 
-        color_support_override_set(ColorSupport::NotSet);
+        global_color_support::clear_override()
     }
 }

--- a/tui/src/tui/color_wheel/color_wheel_struct.rs
+++ b/tui/src/tui/color_wheel/color_wheel_struct.rs
@@ -15,13 +15,9 @@
  *   limitations under the License.
  */
 
-use std::str::FromStr;
-
 use get_size::GetSize;
-use palette::{Gradient, LinSrgb};
 use r3bl_ansi_color::{global_color_support, ColorSupport};
 use r3bl_rs_utils_core::*;
-use rand::Rng;
 use serde::*;
 
 use crate::*;
@@ -293,27 +289,7 @@ impl ColorWheel {
 
             ColorWheelConfig::Rgb(stops, _, _) => {
                 // Generate new gradient.
-                let acc = {
-                    let mut it: Vec<LinSrgb> = vec![];
-                    for color in stops {
-                        let color = LinSrgb::from_str(color)
-                            .expect("Hex color is invalid")
-                            .into_format();
-                        it.push(color);
-                    }
-                    it
-                };
-                let new_gradient: Vec<TuiColor> = Gradient::new(acc)
-                    .take(steps)
-                    .map(|color| {
-                        TuiColor::Rgb(RgbValue::from_f32(
-                            color.red,
-                            color.green,
-                            color.blue,
-                        ))
-                    })
-                    .collect();
-
+                let new_gradient = generate_truecolor_gradient(stops, steps);
                 self.gradient_length_kind =
                     GradientLengthKind::ColorWheel(new_gradient.len());
                 self.gradient_kind = GradientKind::ColorWheel(new_gradient);
@@ -321,35 +297,8 @@ impl ColorWheel {
             }
 
             ColorWheelConfig::RgbRandom(_) => {
-                let mut rng = rand::thread_rng();
-                let gradient = Gradient::new(vec![
-                    LinSrgb::new(
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                    ),
-                    LinSrgb::new(
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                    ),
-                    LinSrgb::new(
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                    ),
-                ]);
-                let new_gradient: Vec<TuiColor> = gradient
-                    .take(steps)
-                    .map(|color| {
-                        TuiColor::Rgb(RgbValue::from_f32(
-                            color.red,
-                            color.green,
-                            color.blue,
-                        ))
-                    })
-                    .collect();
-
+                // Generate new random gradient.
+                let new_gradient = generate_random_truecolor_gradient(steps);
                 self.gradient_length_kind =
                     GradientLengthKind::ColorWheel(new_gradient.len());
                 self.gradient_kind = GradientKind::ColorWheel(new_gradient);
@@ -361,7 +310,6 @@ impl ColorWheel {
                     .iter()
                     .map(|color_u8| TuiColor::Ansi(AnsiValue::new(*color_u8)))
                     .collect();
-
                 self.gradient_length_kind =
                     GradientLengthKind::ColorWheel(gradient.len());
                 self.gradient_kind = GradientKind::ColorWheel(gradient);

--- a/tui/src/tui/color_wheel/mod.rs
+++ b/tui/src/tui/color_wheel/mod.rs
@@ -19,8 +19,10 @@
 pub mod ansi_256_color_gradients;
 pub mod color_wheel_struct;
 pub mod styled_text;
+pub mod truecolor_gradient;
 
 // Re-export.
 pub use ansi_256_color_gradients::*;
 pub use color_wheel_struct::*;
 pub use styled_text::*;
+pub use truecolor_gradient::*;

--- a/tui/src/tui/color_wheel/truecolor_gradient.rs
+++ b/tui/src/tui/color_wheel/truecolor_gradient.rs
@@ -1,0 +1,203 @@
+/*
+ *   Copyright (c) 2023 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+use r3bl_rs_utils_core::{RgbValue, TuiColor};
+use rand::Rng;
+
+/// # Arguments
+/// * `steps` - The number of steps to take between each color stop.
+///
+/// # Returns
+/// A vector of [TuiColor] objects representing the gradient.
+pub fn generate_random_truecolor_gradient(steps: usize) -> Vec<TuiColor> {
+    let mut rng = rand::thread_rng();
+
+    let stops = vec![
+        colorgrad::Color::new(
+            rng.gen_range(0.0..1.0),
+            rng.gen_range(0.0..1.0),
+            rng.gen_range(0.0..1.0),
+            1.0,
+        )
+        .to_hex_string(),
+        colorgrad::Color::new(
+            rng.gen_range(0.0..1.0),
+            rng.gen_range(0.0..1.0),
+            rng.gen_range(0.0..1.0),
+            1.0,
+        )
+        .to_hex_string(),
+        colorgrad::Color::new(
+            rng.gen_range(0.0..1.0),
+            rng.gen_range(0.0..1.0),
+            rng.gen_range(0.0..1.0),
+            1.0,
+        )
+        .to_hex_string(),
+    ];
+
+    generate_truecolor_gradient(&stops, steps)
+}
+
+/// # Arguments
+/// * `stops` - A vector of hex strings representing the color stops.
+/// * `steps` - The number of steps to take between each color stop.
+///
+/// # Returns
+/// A vector of [TuiColor] objects representing the gradient.
+pub fn generate_truecolor_gradient(stops: &Vec<String>, steps: usize) -> Vec<TuiColor> {
+    let colors = stops.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
+
+    let result_gradient = colorgrad::CustomGradient::new()
+        .html_colors(&colors)
+        .build();
+
+    match result_gradient {
+        Ok(gradient) => {
+            let fractional_step: f64 = 1f64 / steps as f64;
+
+            let mut it = vec![];
+
+            for step_count in 0..steps {
+                let color = gradient.at(fractional_step * step_count as f64);
+                let color = color.to_rgba8();
+                it.push(TuiColor::Rgb(RgbValue {
+                    red: color[0],
+                    green: color[1],
+                    blue: color[2],
+                }));
+            }
+
+            return it;
+        }
+        Err(_) => {
+            // Gradient w/ 10 stops going from red to green to blue.
+            [
+                (255, 0, 0),
+                (204, 51, 0),
+                (153, 102, 0),
+                (102, 153, 0),
+                (51, 204, 0),
+                (0, 255, 0),
+                (0, 204, 51),
+                (0, 153, 102),
+                (0, 102, 153),
+                (0, 51, 204),
+            ]
+            .iter()
+            .map(|(red, green, blue)| {
+                TuiColor::Rgb(RgbValue {
+                    red: *red,
+                    green: *green,
+                    blue: *blue,
+                })
+            })
+            .collect::<Vec<TuiColor>>()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use r3bl_ansi_color::{AnsiStyledText, Style};
+    use r3bl_rs_utils_core::assert_eq2;
+
+    use super::*;
+
+    #[test]
+    fn test_generate_random_truecolor_gradient() {
+        let steps = 10;
+        let result = generate_random_truecolor_gradient(steps);
+
+        assert_eq2!(result.len(), steps);
+
+        result
+            .iter()
+            .enumerate()
+            .for_each(|(index, color)| match color {
+                TuiColor::Rgb(c) => {
+                    AnsiStyledText {
+                        text: format!(
+                            " {index}                                                   "
+                        )
+                        .as_str(),
+                        style: &[Style::Background(r3bl_ansi_color::Color::Rgb(
+                            c.red, c.green, c.blue,
+                        ))],
+                    }
+                    .println();
+                }
+                _ => panic!("Unexpected color type"),
+            });
+    }
+
+    #[test]
+    fn test_generate_truecolor_gradient() {
+        let stops = vec!["#ff0000", "#00ff00", "#0000ff"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        let steps = 10;
+        let result = generate_truecolor_gradient(&stops, steps);
+
+        assert_eq2!(result.len(), steps);
+
+        [
+            (255, 0, 0),
+            (204, 51, 0),
+            (153, 102, 0),
+            (102, 153, 0),
+            (51, 204, 0),
+            (0, 255, 0),
+            (0, 204, 51),
+            (0, 153, 102),
+            (0, 102, 153),
+            (0, 51, 204),
+        ]
+        .iter()
+        .enumerate()
+        .for_each(|(i, (red, green, blue))| {
+            assert_eq2!(
+                result[i],
+                TuiColor::Rgb(RgbValue {
+                    red: *red,
+                    green: *green,
+                    blue: *blue,
+                })
+            );
+        });
+
+        result
+            .iter()
+            .enumerate()
+            .for_each(|(index, color)| match color {
+                TuiColor::Rgb(c) => {
+                    AnsiStyledText {
+                        text: format!(
+                            " {index}                                                   "
+                        )
+                        .as_str(),
+                        style: &[Style::Background(r3bl_ansi_color::Color::Rgb(
+                            c.red, c.green, c.blue,
+                        ))],
+                    }
+                    .println();
+                }
+                _ => panic!("Unexpected color type"),
+            });
+    }
+}

--- a/tui/src/tui/lolcat/lolcat_impl.rs
+++ b/tui/src/tui/lolcat/lolcat_impl.rs
@@ -58,9 +58,10 @@ impl Debug for Lolcat {
 }
 
 impl Lolcat {
-    /// This function does not respect [r3bl_ansi_color::detect_color_support()] (it will
-    /// always colorize to truecolor regardless of terminal limitations). Use [ColorWheel]
-    /// if you want to respect [r3bl_ansi_color::detect_color_support()].
+    /// This function does not respect [r3bl_ansi_color::global_color_support::detect()]
+    /// (it will always colorize to truecolor regardless of terminal limitations). Use
+    /// [ColorWheel] if you want to respect
+    /// [r3bl_ansi_color::global_color_support::detect].
     pub fn colorize_to_styled_texts(&mut self, input: &UnicodeString) -> StyledTexts {
         let mut acc = StyledTexts::default();
 

--- a/tui/src/tui/syntax_highlighting/md_parser_syn_hi/md_parser_stylesheet.rs
+++ b/tui/src/tui/syntax_highlighting/md_parser_syn_hi/md_parser_stylesheet.rs
@@ -19,7 +19,7 @@
 //! [ColorSupport] constraints. You can find ANSI colors
 //! [here](https://www.ditig.com/256-colors-cheat-sheet).
 
-use r3bl_ansi_color::{detect_color_support, ColorSupport};
+use r3bl_ansi_color::{global_color_support, ColorSupport};
 use r3bl_rs_utils_core::*;
 use r3bl_rs_utils_macro::style;
 
@@ -39,7 +39,7 @@ pub fn get_selection_style() -> Style {
 /// style. It is overridden by other styles like bold, italic, etc. below.
 pub fn get_foreground_style() -> Style {
     style! {
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#c1b3d0")),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(244)), // Grey50.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::White),
@@ -63,7 +63,7 @@ pub fn get_foreground_dim_style() -> Style {
 pub fn get_bold_style() -> Style {
     style! {
         attrib: [bold]
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#dacd24")),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(226)), // Yellow1.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Yellow),
@@ -76,7 +76,7 @@ pub fn get_bold_style() -> Style {
 pub fn get_italic_style() -> Style {
     style! {
         attrib: [italic]
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#a59e3a")),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(208)), // DarkOrange.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::DarkYellow),
@@ -89,7 +89,7 @@ pub fn get_italic_style() -> Style {
 pub fn get_bold_italic_style() -> Style {
     style! {
         attrib: [bold, italic]
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#dacd24")),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(184)), // Yellow3.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Yellow),
@@ -101,7 +101,7 @@ pub fn get_bold_italic_style() -> Style {
 /// This is just for the bold content, not the enclosing "`".
 pub fn get_inline_code_style() -> Style {
     style! {
-        color_fg: match detect_color_support(){
+        color_fg: match global_color_support::detect(){
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#ce55b7")),
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Magenta),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(169)), // HotPink2.
@@ -113,7 +113,7 @@ pub fn get_inline_code_style() -> Style {
 /// This is just for the link text not the enclosing `[` and `]`.
 pub fn get_link_text_style() -> Style {
     style! {
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#4f86ed")),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(33)), // DodgerBlue1.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Blue),
@@ -126,7 +126,7 @@ pub fn get_link_text_style() -> Style {
 pub fn get_link_url_style() -> Style {
     style! {
         attrib: [underline]
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#16adf3")),
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(39)), // DeepSkyBlue1.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Blue),
@@ -139,7 +139,7 @@ pub fn get_link_url_style() -> Style {
 pub fn get_checkbox_checked_style() -> Style {
     style! {
         attrib: [bold, dim]
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::DarkMagenta),
             _ => TuiColor::Rgb(RgbValue::from_hex("#14a45b")),
         }
@@ -150,7 +150,7 @@ pub fn get_checkbox_checked_style() -> Style {
 pub fn get_checkbox_unchecked_style() -> Style {
     style! {
         attrib: [bold]
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Green),
             _ => TuiColor::Rgb(RgbValue::from_hex("#e1ff2f"))
         }
@@ -160,7 +160,7 @@ pub fn get_checkbox_unchecked_style() -> Style {
 /// This is for the bullet or numbered bullet of a list item, not the content.
 pub fn get_list_bullet_style() -> Style {
     style! {
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Yellow), // There is no equivalent.
             _ => TuiColor::Rgb(RgbValue::from_hex("#f8f8a6")), // Pale yellow.
         }
@@ -183,7 +183,7 @@ pub fn get_code_block_content_style() -> Style {
 pub fn get_metadata_title_marker_style() -> Style {
     style! {
         color_fg: TuiColor::Basic(ANSIBasicColor::Black)
-        color_bg: match detect_color_support() {
+        color_bg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#4f86ed")), // Soft blue.
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(39)), // DeepSkyBlue1.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Cyan), // There is no equivalent.
@@ -196,13 +196,13 @@ pub fn get_metadata_title_marker_style() -> Style {
 /// - Bg color: #444444
 pub fn get_metadata_title_value_style() -> Style {
     style! {
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#4fcbd4")), // Moderate cyan.
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(51)), // Cyan1.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Cyan),
             _ => TuiColor::Basic(ANSIBasicColor::Cyan),
         }
-        color_bg: match detect_color_support() {
+        color_bg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#444444")), // Very dark gray.
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(238)), // Grey27.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::DarkGrey),
@@ -216,7 +216,7 @@ pub fn get_metadata_title_value_style() -> Style {
 pub fn get_metadata_tags_marker_style() -> Style {
     style! {
         color_fg: TuiColor::Basic(ANSIBasicColor::Black)
-        color_bg: match detect_color_support() {
+        color_bg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#ad83da")), // Very soft violet.
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(133)), // MediumOrchid3. There is no equivalent.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Yellow), // There is no equivalent.
@@ -229,13 +229,13 @@ pub fn get_metadata_tags_marker_style() -> Style {
 /// - Bg color: #303030
 pub fn get_metadata_tags_values_style() -> Style {
     style! {
-        color_fg: match detect_color_support() {
+        color_fg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#e2a1e3")), // Soft violet.
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(45)), // Turquoise2
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::Cyan), // There is no equivalent.
             _ => TuiColor::Basic(ANSIBasicColor::Cyan),
         }
-        color_bg: match detect_color_support() {
+        color_bg: match global_color_support::detect() {
             ColorSupport::Truecolor => TuiColor::Rgb(RgbValue::from_hex("#303030")), // Very dark gray.
             ColorSupport::Ansi256 => TuiColor::Ansi(AnsiValue::new(236)), // Grey19.
             ColorSupport::Grayscale => TuiColor::Basic(ANSIBasicColor::DarkGrey),

--- a/tui/src/tui/syntax_highlighting/md_parser_syn_hi/md_parser_syn_hi_impl.rs
+++ b/tui/src/tui/syntax_highlighting/md_parser_syn_hi/md_parser_syn_hi_impl.rs
@@ -130,8 +130,7 @@ impl StyleUSSpanLines {
         lines
     }
 
-    /// Based on [r3bl_ansi_color::detect_color_support()] & language we have the
-    /// following:
+    /// Based on [global_color_support::detect] & language we have the following:
     /// ```text
     /// |               | Truecolor      | ANSI           |
     /// |---------------|----------------|----------------|

--- a/tui/src/tui/terminal_lib_backends/color_converter.rs
+++ b/tui/src/tui/terminal_lib_backends/color_converter.rs
@@ -15,37 +15,39 @@
  *   limitations under the License.
  */
 
-use r3bl_ansi_color::{detect_color_support, ColorSupport};
+use r3bl_ansi_color::{global_color_support, ColorSupport, TransformColor};
 use r3bl_rs_utils_core::*;
 
+#[rustfmt::skip]
 pub fn from_crossterm_color(value: crossterm::style::Color) -> TuiColor {
     match value {
-        crossterm::style::Color::Reset => TuiColor::Reset,
-        crossterm::style::Color::Black => TuiColor::Basic(ANSIBasicColor::Black),
-        crossterm::style::Color::DarkGrey => TuiColor::Basic(ANSIBasicColor::DarkGrey),
-        crossterm::style::Color::Red => TuiColor::Basic(ANSIBasicColor::Red),
-        crossterm::style::Color::DarkRed => TuiColor::Basic(ANSIBasicColor::DarkRed),
-        crossterm::style::Color::Green => TuiColor::Basic(ANSIBasicColor::Green),
-        crossterm::style::Color::DarkGreen => TuiColor::Basic(ANSIBasicColor::DarkGreen),
-        crossterm::style::Color::Yellow => TuiColor::Basic(ANSIBasicColor::Yellow),
-        crossterm::style::Color::DarkYellow => {
-            TuiColor::Basic(ANSIBasicColor::DarkYellow)
-        }
-        crossterm::style::Color::Blue => TuiColor::Basic(ANSIBasicColor::Blue),
-        crossterm::style::Color::DarkBlue => TuiColor::Basic(ANSIBasicColor::DarkBlue),
-        crossterm::style::Color::Magenta => TuiColor::Basic(ANSIBasicColor::Magenta),
-        crossterm::style::Color::DarkMagenta => {
-            TuiColor::Basic(ANSIBasicColor::DarkMagenta)
-        }
-        crossterm::style::Color::Cyan => TuiColor::Basic(ANSIBasicColor::Cyan),
-        crossterm::style::Color::DarkCyan => TuiColor::Basic(ANSIBasicColor::DarkCyan),
-        crossterm::style::Color::White => TuiColor::Basic(ANSIBasicColor::White),
-        crossterm::style::Color::Grey => TuiColor::Basic(ANSIBasicColor::Grey),
+        // Basic colors.
+        crossterm::style::Color::Reset       => TuiColor::Reset,
+        crossterm::style::Color::Black       => TuiColor::Basic(ANSIBasicColor::Black),
+        crossterm::style::Color::DarkGrey    => TuiColor::Basic(ANSIBasicColor::DarkGrey),
+        crossterm::style::Color::Red         => TuiColor::Basic(ANSIBasicColor::Red),
+        crossterm::style::Color::DarkRed     => TuiColor::Basic(ANSIBasicColor::DarkRed),
+        crossterm::style::Color::Green       => TuiColor::Basic(ANSIBasicColor::Green),
+        crossterm::style::Color::DarkGreen   => TuiColor::Basic(ANSIBasicColor::DarkGreen),
+        crossterm::style::Color::Yellow      => TuiColor::Basic(ANSIBasicColor::Yellow),
+        crossterm::style::Color::DarkYellow  => TuiColor::Basic(ANSIBasicColor::DarkYellow),
+        crossterm::style::Color::Blue        => TuiColor::Basic(ANSIBasicColor::Blue),
+        crossterm::style::Color::DarkBlue    => TuiColor::Basic(ANSIBasicColor::DarkBlue),
+        crossterm::style::Color::Magenta     => TuiColor::Basic(ANSIBasicColor::Magenta),
+        crossterm::style::Color::DarkMagenta => TuiColor::Basic(ANSIBasicColor::DarkMagenta),
+        crossterm::style::Color::Cyan        => TuiColor::Basic(ANSIBasicColor::Cyan),
+        crossterm::style::Color::DarkCyan    => TuiColor::Basic(ANSIBasicColor::DarkCyan),
+        crossterm::style::Color::White       => TuiColor::Basic(ANSIBasicColor::White),
+        crossterm::style::Color::Grey        => TuiColor::Basic(ANSIBasicColor::Grey),
+
+        // RGB colors.
         crossterm::style::Color::Rgb { r, g, b } => TuiColor::Rgb(RgbValue {
             red: r,
             green: g,
             blue: b,
         }),
+
+        // ANSI colors.
         crossterm::style::Color::AnsiValue(number) => {
             TuiColor::Ansi(AnsiValue::new(number))
         }
@@ -54,92 +56,99 @@ pub fn from_crossterm_color(value: crossterm::style::Color) -> TuiColor {
 
 /// Respect the color support of the terminal and downgrade the color if needed. This really only
 /// applies to the [TuiColor::Rgb] variant.
-pub fn to_crossterm_color(value: TuiColor) -> crossterm::style::Color {
-    match value {
+pub fn to_crossterm_color(from_tui_color: TuiColor) -> crossterm::style::Color {
+    match from_tui_color {
         TuiColor::Reset => crossterm::style::Color::Reset,
 
-        TuiColor::Basic(basic_color) => match detect_color_support() {
+        TuiColor::Basic(from_basic_color) => match global_color_support::detect() {
             // Convert to grayscale.
-            // <https://www.ditig.com/256-colors-cheat-sheet>
             #[rustfmt::skip]
-            ColorSupport::NoColor | ColorSupport::NotSet | ColorSupport::Grayscale => match basic_color {
+            ColorSupport::NoColor | ColorSupport::Grayscale => match from_basic_color {
                 ANSIBasicColor::Black =>       crossterm::style::Color::Black,
                 ANSIBasicColor::White =>       crossterm::style::Color::White,
-                ANSIBasicColor::Grey =>        convert_rgb_to_grayscale(192, 192, 192),
-                ANSIBasicColor::DarkGrey =>    convert_rgb_to_grayscale(128, 128, 128),
-                ANSIBasicColor::Red =>         convert_rgb_to_grayscale(255, 0,   0),
-                ANSIBasicColor::DarkRed =>     convert_rgb_to_grayscale(128, 0,   0),
-                ANSIBasicColor::Green =>       convert_rgb_to_grayscale(0,   255, 0),
-                ANSIBasicColor::DarkGreen =>   convert_rgb_to_grayscale(0,   128, 0),
-                ANSIBasicColor::Yellow =>      convert_rgb_to_grayscale(255, 255, 0),
-                ANSIBasicColor::DarkYellow =>  convert_rgb_to_grayscale(128, 128, 0),
-                ANSIBasicColor::Blue =>        convert_rgb_to_grayscale(0,   0,   255),
-                ANSIBasicColor::DarkBlue =>    convert_rgb_to_grayscale(0,   0,   128),
-                ANSIBasicColor::Magenta =>     convert_rgb_to_grayscale(255, 0,   255),
-                ANSIBasicColor::DarkMagenta => convert_rgb_to_grayscale(128, 0,   128),
-                ANSIBasicColor::Cyan =>        convert_rgb_to_grayscale(0,   255, 255),
-                ANSIBasicColor::DarkCyan =>    convert_rgb_to_grayscale(0,   128, 128),
+                ANSIBasicColor::Grey =>        convert_rgb_to_ansi_grayscale(192, 192, 192),
+                ANSIBasicColor::DarkGrey =>    convert_rgb_to_ansi_grayscale(128, 128, 128),
+                ANSIBasicColor::Red =>         convert_rgb_to_ansi_grayscale(255, 0,   0),
+                ANSIBasicColor::DarkRed =>     convert_rgb_to_ansi_grayscale(128, 0,   0),
+                ANSIBasicColor::Green =>       convert_rgb_to_ansi_grayscale(0,   255, 0),
+                ANSIBasicColor::DarkGreen =>   convert_rgb_to_ansi_grayscale(0,   128, 0),
+                ANSIBasicColor::Yellow =>      convert_rgb_to_ansi_grayscale(255, 255, 0),
+                ANSIBasicColor::DarkYellow =>  convert_rgb_to_ansi_grayscale(128, 128, 0),
+                ANSIBasicColor::Blue =>        convert_rgb_to_ansi_grayscale(0,   0,   255),
+                ANSIBasicColor::DarkBlue =>    convert_rgb_to_ansi_grayscale(0,   0,   128),
+                ANSIBasicColor::Magenta =>     convert_rgb_to_ansi_grayscale(255, 0,   255),
+                ANSIBasicColor::DarkMagenta => convert_rgb_to_ansi_grayscale(128, 0,   128),
+                ANSIBasicColor::Cyan =>        convert_rgb_to_ansi_grayscale(0,   255, 255),
+                ANSIBasicColor::DarkCyan =>    convert_rgb_to_ansi_grayscale(0,   128, 128),
             },
 
             // Keep it as is.
-            ColorSupport::Ansi256 | ColorSupport::Truecolor => match basic_color {
-                ANSIBasicColor::Black => crossterm::style::Color::Black,
-                ANSIBasicColor::White => crossterm::style::Color::White,
-                ANSIBasicColor::Grey => crossterm::style::Color::Grey,
-                ANSIBasicColor::DarkGrey => crossterm::style::Color::DarkGrey,
-                ANSIBasicColor::Red => crossterm::style::Color::Red,
-                ANSIBasicColor::DarkRed => crossterm::style::Color::DarkRed,
-                ANSIBasicColor::Green => crossterm::style::Color::Green,
-                ANSIBasicColor::DarkGreen => crossterm::style::Color::DarkGreen,
-                ANSIBasicColor::Yellow => crossterm::style::Color::Yellow,
-                ANSIBasicColor::DarkYellow => crossterm::style::Color::DarkYellow,
-                ANSIBasicColor::Blue => crossterm::style::Color::Blue,
-                ANSIBasicColor::DarkBlue => crossterm::style::Color::DarkBlue,
-                ANSIBasicColor::Magenta => crossterm::style::Color::Magenta,
-                ANSIBasicColor::DarkMagenta => crossterm::style::Color::DarkMagenta,
-                ANSIBasicColor::Cyan => crossterm::style::Color::Cyan,
-                ANSIBasicColor::DarkCyan => crossterm::style::Color::DarkCyan,
+            #[rustfmt::skip]
+            ColorSupport::Ansi256 | ColorSupport::Truecolor => match from_basic_color {
+                ANSIBasicColor::Black =>        crossterm::style::Color::Black,
+                ANSIBasicColor::White =>        crossterm::style::Color::White,
+                ANSIBasicColor::Grey =>         crossterm::style::Color::Grey,
+                ANSIBasicColor::DarkGrey =>     crossterm::style::Color::DarkGrey,
+                ANSIBasicColor::Red =>          crossterm::style::Color::Red,
+                ANSIBasicColor::DarkRed =>      crossterm::style::Color::DarkRed,
+                ANSIBasicColor::Green =>        crossterm::style::Color::Green,
+                ANSIBasicColor::DarkGreen =>    crossterm::style::Color::DarkGreen,
+                ANSIBasicColor::Yellow =>       crossterm::style::Color::Yellow,
+                ANSIBasicColor::DarkYellow =>   crossterm::style::Color::DarkYellow,
+                ANSIBasicColor::Blue =>         crossterm::style::Color::Blue,
+                ANSIBasicColor::DarkBlue =>     crossterm::style::Color::DarkBlue,
+                ANSIBasicColor::Magenta =>      crossterm::style::Color::Magenta,
+                ANSIBasicColor::DarkMagenta =>  crossterm::style::Color::DarkMagenta,
+                ANSIBasicColor::Cyan =>         crossterm::style::Color::Cyan,
+                ANSIBasicColor::DarkCyan =>     crossterm::style::Color::DarkCyan,
             },
         },
 
-        // Keep it as is.
-        TuiColor::Ansi(ansi_value) => {
-            crossterm::style::Color::AnsiValue(ansi_value.color)
+        TuiColor::Ansi(from_ansi_value) => {
+            match global_color_support::detect() {
+                // Keep it as is.
+                ColorSupport::Truecolor | ColorSupport::Ansi256 => {
+                    crossterm::style::Color::AnsiValue(from_ansi_value.color)
+                }
+
+                // Convert to grayscale.
+                ColorSupport::Grayscale | ColorSupport::NoColor => {
+                    let ansi_grayscale_color =
+                        r3bl_ansi_color::Color::Ansi256(from_ansi_value.color)
+                            .as_grayscale();
+                    crossterm::style::Color::AnsiValue(ansi_grayscale_color.index)
+                }
+            }
         }
 
         // Downgrade the color if needed.
-        TuiColor::Rgb(rgb_value) => {
+        TuiColor::Rgb(from_rgb_value) => {
             let RgbValue {
                 red: r,
                 green: g,
                 blue: b,
-            } = rgb_value;
+            } = from_rgb_value;
 
-            match detect_color_support() {
+            match global_color_support::detect() {
+                // Keep it as is.
                 ColorSupport::Truecolor => crossterm::style::Color::Rgb { r, g, b },
+
+                // Convert to ANSI256.
                 ColorSupport::Ansi256 => {
-                    let ansi_value = AnsiValue::from(rgb_value).color;
+                    let ansi_value = AnsiValue::from(from_rgb_value).color;
                     crossterm::style::Color::AnsiValue(ansi_value)
                 }
-                ColorSupport::NoColor
-                | ColorSupport::NotSet
-                | ColorSupport::Grayscale => convert_rgb_to_grayscale(r, g, b),
+
+                // Convert to grayscale.
+                ColorSupport::NoColor | ColorSupport::Grayscale => {
+                    convert_rgb_to_ansi_grayscale(r, g, b)
+                }
             }
         }
     }
 }
 
-/// More info: <https://goodcalculators.com/rgb-to-grayscale-conversion-calculator/>
-fn convert_rgb_to_grayscale(r: u8, g: u8, b: u8) -> crossterm::style::Color {
-    let r = 0.299 * r as f32;
-    let g = 0.587 * g as f32;
-    let b = 0.114 * b as f32;
-
-    let sum = r + g + b;
-
-    crossterm::style::Color::Rgb {
-        r: sum as u8,
-        g: sum as u8,
-        b: sum as u8,
-    }
+fn convert_rgb_to_ansi_grayscale(r: u8, g: u8, b: u8) -> crossterm::style::Color {
+    let ansi_grayscale_color = r3bl_ansi_color::Color::Rgb(r, g, b).as_grayscale();
+    crossterm::style::Color::AnsiValue(ansi_grayscale_color.index)
 }

--- a/tui/src/tui/terminal_window/static_global_data.rs
+++ b/tui/src/tui/terminal_window/static_global_data.rs
@@ -21,14 +21,15 @@ use chrono::Utc;
 
 const NOT_SET_VALUE: i64 = -1;
 
-/// This module contains static global data that is meant to be used by the entire application. It
-/// also provides functions to manipulate this data.
+/// This module contains static global data that is meant to be used by the entire
+/// application. It also provides functions to manipulate this data.
 ///
 /// ### Color support
+///
 /// The app can override the color support detection heuristics by providing a
-/// [r3bl_ansi_color::detect_color_support()] value. It is not always possible to accurately
-/// detect the color support of the terminal. So this gives the app a way to set it to
-/// whatever the user wants (for example).
+/// [r3bl_ansi_color::global_color_support::detect] value. It is not always possible to
+/// accurately detect the color support of the terminal. So this gives the app a way to
+/// set it to whatever the user wants (for example).
 pub mod telemetry_global_static {
     use super::*;
 

--- a/tuify/src/components/apply_style_macro.rs
+++ b/tuify/src/components/apply_style_macro.rs
@@ -16,13 +16,12 @@
  */
 
 use crossterm::style::*;
-use r3bl_ansi_color::{detect_color_support,
-                      Color as RColor,
-                      ColorSupport,
-                      TransformColor};
+use r3bl_ansi_color::{global_color_support, ColorSupport, TransformColor};
 
-pub fn get_crossterm_color_based_on_terminal_capabilities(color: RColor) -> Color {
-    let detect_color_support = detect_color_support();
+pub fn get_crossterm_color_based_on_terminal_capabilities(
+    color: r3bl_ansi_color::Color,
+) -> Color {
+    let detect_color_support = global_color_support::detect();
     match detect_color_support {
         ColorSupport::Truecolor => {
             let rgb_color = color.as_rgb();


### PR DESCRIPTION
palette crate dropped support for Gradient in the latest release
which prevented its latest version to be used. So dropping it here
in favor of the colorgrad crate.

Fixes: #162