### PR TITLE
[tui] Add cut selected text support in editor component

### DIFF
--- a/tui/examples/demo/ex_editor/app.rs
+++ b/tui/examples/demo/ex_editor/app.rs
@@ -723,7 +723,7 @@ mod status_bar {
     pub fn render_status_bar(pipeline: &mut RenderPipeline, size: &Size) {
         let styled_texts = styled_texts! {
             styled_text! { @style: style!(attrib: [bold, dim]) ,      @text: "Hints: "},
-            styled_text! { @style: style!(attrib: [dim, underline]) , @text: "Ctrl + x"},
+            styled_text! { @style: style!(attrib: [dim, underline]) , @text: "Ctrl + q"},
             styled_text! { @style: style!(attrib: [bold]) ,           @text: " : Exit 🖖"},
             styled_text! { @style: style!(attrib: [dim]) ,            @text: " … "},
             styled_text! { @style: style!(attrib: [dim, underline]) , @text: "Ctrl + l"},

--- a/tui/examples/demo/ex_editor/launcher.rs
+++ b/tui/examples/demo/ex_editor/launcher.rs
@@ -37,7 +37,7 @@ pub async fn run_app() -> CommonResult<()> {
 
         // Exit if these keys are pressed.
         let exit_keys: Vec<InputEvent> = vec![InputEvent::Keyboard(
-            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'x' },
+            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'q' },
         )];
 
         // Create a window.

--- a/tui/examples/demo/ex_pitch/app.rs
+++ b/tui/examples/demo/ex_pitch/app.rs
@@ -313,7 +313,7 @@ mod status_bar {
     pub fn render_status_bar(pipeline: &mut RenderPipeline, size: &Size, state: &State) {
         let mut it = styled_texts! {
             styled_text! { @style:style!(attrib: [dim, bold]) ,      @text: "Exit 👋 : "},
-            styled_text! { @style:style!(attrib: [dim, underline]) , @text: "Ctrl + x"},
+            styled_text! { @style:style!(attrib: [dim, underline]) , @text: "Ctrl + q"},
         };
 
         if state.current_slide_index < LINES_ARRAY.len() - 1 {

--- a/tui/examples/demo/ex_pitch/launcher.rs
+++ b/tui/examples/demo/ex_pitch/launcher.rs
@@ -37,7 +37,7 @@ pub async fn run_app() -> CommonResult<()> {
 
         // Exit if these keys are pressed.
         let exit_keys: Vec<InputEvent> = vec![InputEvent::Keyboard(
-            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'x' },
+            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'q' },
         )];
 
         // Create a window.

--- a/tui/examples/demo/ex_rc/app.rs
+++ b/tui/examples/demo/ex_rc/app.rs
@@ -175,9 +175,9 @@ mod app_with_layout_impl_trait_app {
                 return Ok(EventPropagation::Consumed);
             };
 
-            // x => Cancel animation & don't consume the event.
+            // q => Cancel animation & don't consume the event.
             if input_event.matches_keypress(KeyPress::WithModifiers {
-                key: Key::Character('x'),
+                key: Key::Character('q'),
                 mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 self.animator.stop();
@@ -396,7 +396,7 @@ mod status_bar {
         it += lolcat_st;
 
         it += styled_text! { @style:style!(attrib: [dim, bold]) ,      @text: " Exit 👋 : "};
-        it += styled_text! { @style:style!(attrib: [dim, underline]) , @text: "Ctrl + x"};
+        it += styled_text! { @style:style!(attrib: [dim, underline]) , @text: "Ctrl + q"};
 
         if state.current_slide_index < LINES_ARRAY.len() - 1 {
             it += styled_text! { @style: style!(attrib: [dim, bold]) ,      @text: " ┊ "};

--- a/tui/examples/demo/ex_rc/launcher.rs
+++ b/tui/examples/demo/ex_rc/launcher.rs
@@ -37,7 +37,7 @@ pub async fn run_app() -> CommonResult<()> {
 
         // Exit if these keys are pressed.
         let exit_keys: Vec<InputEvent> = vec![InputEvent::Keyboard(
-            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'x' },
+            keypress! { @char ModifierKeysMask::new().with_ctrl(), 'q' },
         )];
 
         // Create a window.

--- a/tui/src/tui/editor/editor_component/editor_event.rs
+++ b/tui/src/tui/editor/editor_component/editor_event.rs
@@ -44,6 +44,7 @@ pub enum EditorEvent {
     Select(SelectionScope),
     Copy,
     Paste,
+    Cut,
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -169,6 +170,16 @@ impl TryFrom<&InputEvent> for EditorEvent {
                         alt_key_state: KeyState::NotPressed,
                     },
             }) => Ok(EditorEvent::Copy),
+
+            InputEvent::Keyboard(KeyPress::WithModifiers {
+                key: Key::Character('x'),
+                mask:
+                    ModifierKeysMask {
+                        ctrl_key_state: KeyState::Pressed,
+                        shift_key_state: KeyState::NotPressed,
+                        alt_key_state: KeyState::NotPressed,
+                    },
+            }) => Ok(EditorEvent::Cut),
 
             InputEvent::Keyboard(KeyPress::WithModifiers {
                 key: Key::Character('v'),
@@ -452,6 +463,13 @@ impl EditorEvent {
                     );
                 }
             },
+
+            EditorEvent::Cut => {
+                EditorEngineInternalApi::copy_editor_selection_to_clipboard(
+                    editor_buffer,
+                );
+                Self::delete_text_if_selected(editor_engine, editor_buffer);
+            }
 
             EditorEvent::Copy => {
                 EditorEngineInternalApi::copy_editor_selection_to_clipboard(

--- a/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
@@ -1426,36 +1426,48 @@ mod content_mut {
 
         let lines = buffer.get_lines();
 
-        let copied_selected_lines_map: HashMap<RowIndex, &str> =
-            my_selection_map.get_selected_lines(buffer);
+        let selected_row_indices: Vec<ChUnit> = my_selection_map.get_ordered_indices();
 
-        let row_indices: Vec<ChUnit> = my_selection_map.get_indices();
+        let mut vec_row_indices_to_remove = vec![];
+        let mut map_lines_to_replace = HashMap::new();
 
-        let mut lines_to_remove = vec![];
-        let mut lines_to_replace = HashMap::new();
+        for selected_row_index in selected_row_indices {
+            match my_selection_map.get(selected_row_index) {
+                Some(selection_range) => {
+                    let line_width = buffer.get_line_display_width(selected_row_index);
 
-        for row_index in row_indices {
-            // Remove entire line.
-            if copied_selected_lines_map[&row_index]
-                == lines[ch!(@to_usize row_index)].string.as_str()
-            {
-                lines_to_remove.push(row_index);
-            }
-            // Remove only selected portion of line.
-            else {
-                if let Some(selection_range) = my_selection_map.get(row_index) {
+                    // Remove entire line.
+                    if selection_range.start_display_col_index == ch!(0)
+                        && selection_range.end_display_col_index == line_width
+                    {
+                        vec_row_indices_to_remove.push(selected_row_index);
+                        continue;
+                    }
+
+                    // Skip if selection range is empty.
+                    if selection_range.start_display_col_index
+                        == selection_range.end_display_col_index
+                    {
+                        continue;
+                    }
+
+                    // Remove selection range (part of the line).
                     let start_col_index = selection_range.start_display_col_index;
                     let end_col_index = selection_range.end_display_col_index;
-                    let line = lines[ch!(@to_usize row_index)].clone();
+                    let line = lines[ch!(@to_usize selected_row_index)].clone();
+
                     let keep_before_selected =
                         line.clip_to_width(ch!(0), start_col_index);
-                    let keep_after_selected = line
-                        .clip_to_width(ch!(end_col_index), ch!(line.string.len() as u16));
+
+                    let keep_after_selected =
+                        line.clip_to_width(ch!(end_col_index), line_width);
+
                     let mut remaining_text = String::new();
                     remaining_text.push_str(keep_before_selected);
                     remaining_text.push_str(keep_after_selected);
-                    lines_to_replace.insert(row_index, remaining_text);
+                    map_lines_to_replace.insert(selected_row_index, remaining_text);
                 }
+                _ => (),
             }
         }
 
@@ -1464,15 +1476,16 @@ mod content_mut {
             engine,
             |lines, caret, _scroll_offset| {
                 // Replace lines, before removing them (to prevent indices from being invalidated).
-                for row_index in lines_to_replace.keys() {
+                for row_index in map_lines_to_replace.keys() {
                     let _ = replace(
                         &mut lines[ch!(@to_usize *row_index)],
-                        lines_to_replace[row_index].clone().into(),
+                        map_lines_to_replace[row_index].clone().into(),
                     );
                 }
 
-                // Remove lines.
-                for row_index in lines_to_remove {
+                // Remove lines in inverse order, in order to preserve the validity of indices.
+                vec_row_indices_to_remove.reverse();
+                for row_index in vec_row_indices_to_remove {
                     lines.remove(ch!(@to_usize row_index));
                 }
 


### PR DESCRIPTION
Make all the tui examples use "Ctrl + q" for exit, since "Ctrl + x" is now used for Cut.

Fixes: #144